### PR TITLE
add plone4 dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add plone.app.contenttypes and z3c.relationfield as dependencies.
+  [erral]
 
 
 1.0 (2021-04-27)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ setup(
         "plone.api>=1.8.4",
         "plone.restapi",
         "hurry.filesize",
+        "plone.app.contenttypes",
+        "z3c.relationfield",
     ],
     entry_points="""
     [z3c.autoinclude.plugin]


### PR DESCRIPTION
Include plone.app.contenttypes and z3c.relationfield as dependencies because they are not included by default in Plone 4 (although their version pins exist in the [KGS](https://dist.plone.org/release/4.3.20/versions.cfg).

There are some version pins needed also for Plone 4 (due to plone.restapi's dependency changes for python 2 vs. 3), perhaps this should be documented on plone.restapi side or even here too in the README.
