### PR TITLE
Basic test setup with tox and GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+        # [Python version, tox env]
+        - ["2.7",   "plone52-py27"]
+        - ["3.8",   "plone52-py38"]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config[1] }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.config[0] }}
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Test
+      run: tox -e ${{ matrix.config[1] }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add option to import file from server.
+  [maurits]
 
 
 1.0 (2021-04-27)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -24,7 +24,7 @@ environment-vars =
 eggs =
     Plone
     Pillow
-    collective.exportimport [test]
+    collective.exportimport
 
 [omelette]
 recipe = collective.recipe.omelette

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,9 +11,11 @@ parts =
     instance
     omelette
     releaser
+    test
 
 develop = .
-
+package-name = collective.exportimport
+package-extras = [test]
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,11 @@ setup(
         "ijson",
     ],
     extras_require={
-        "test": ["plone.app.testing"],
+        "test": [
+            "plone.app.testing",
+            # needed as test dependency of plone.app.event:
+            "plone.app.robotframework",
+        ],
     },
     entry_points="""
     [z3c.autoinclude.plugin]

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
         "hurry.filesize",
         "ijson",
     ],
+    extras_require={
+        "test": ["plone.app.testing"],
+    },
     entry_points="""
     [z3c.autoinclude.plugin]
     target = plone

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -8,6 +8,7 @@
     i18n_domain="collective.exportimport">
 
   <i18n:registerTranslations directory="locales" />
+  <include package="Products.CMFCore" />
 
   <!-- Exports -->
   <browser:page

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -152,7 +152,12 @@ class ExportMembers(BrowserView):
         acl = api.portal.get_tool("acl_users")
         users = acl.source_users
         passwords = users._user_passwords
-        return passwords.get(userId, "")
+        password = passwords.get(userId, "")
+        if six.PY3 and isinstance(password, bytes):
+            # bytes are not json serializable.
+            # Happens at least in the tests.
+            password = password.decode("utf-8")
+        return password
 
     def _getUserData(self, userId):
         member = self.pms.getMemberById(userId)
@@ -168,6 +173,7 @@ class ExportMembers(BrowserView):
         ]
         # userid, password, roles
         props = {
+            # TODO: We should have userid and username (login name).
             "username": userId,
             "password": self._getUserPassword(userId),
             "roles": json_compatible(roles),

--- a/src/collective/exportimport/templates/import_content.pt
+++ b/src/collective/exportimport/templates/import_content.pt
@@ -17,6 +17,23 @@
                 <input type="file" name="jsonfile"/><br/>
             </div>
 
+            <tal:block define="server_files view/server_files">
+              <p i18n:translate="server_paths_list">Or you can choose a file that is already uploaded on the server in one of these paths:</p>
+              <ul>
+                <li tal:repeat="path view/import_paths"><code tal:content="path" /></li>
+              </ul>
+              <p tal:condition="not:server_files" i18n:translate="">No files found.</p>
+              <div class="field mb-3" tal:condition="server_files">
+                <label for="server_file" i18n:translate="">File on server to import:</label>
+                <br />
+                <select id="server_file" name="server_file">
+                  <option selected="" value="" title="" i18n:translate="">Choose one</option>
+                  <option tal:repeat="filename server_files" tal:content="filename" tal:attributes="value filename">
+                  </option>
+                </select>
+              </div>
+            </tal:block>
+
             <div class="field">
               <label>
                 <input

--- a/src/collective/exportimport/testing.py
+++ b/src/collective/exportimport/testing.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
+
+import collective.exportimport
+
+
+class CollectiveExportimportLayer(PloneSandboxLayer):
+
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        # Load any other ZCML that is required for your tests.
+        # The z3c.autoinclude feature is disabled in the Plone fixture base
+        # layer.
+        import plone.restapi
+
+        self.loadZCML(package=plone.restapi)
+        self.loadZCML(package=collective.exportimport)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, "plone.restapi:default")
+
+
+COLLECTIVE_EXPORTIMPORT_FIXTURE = CollectiveExportimportLayer()
+
+
+COLLECTIVE_EXPORTIMPORT_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(COLLECTIVE_EXPORTIMPORT_FIXTURE,),
+    name="CollectiveExportimportLayer:IntegrationTesting",
+)
+
+
+COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(COLLECTIVE_EXPORTIMPORT_FIXTURE,),
+    name="CollectiveExportimportLayer:FunctionalTesting",
+)

--- a/src/collective/exportimport/testing.py
+++ b/src/collective/exportimport/testing.py
@@ -4,7 +4,6 @@ from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
-from plone.testing import z2
 
 import collective.exportimport
 

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
-from collective.exportimport.testing import COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING  # noqa: E501
+from collective.exportimport.testing import (
+    COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,
+)  # noqa: E501
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
 
+import json
 import unittest
 
 
@@ -35,3 +39,24 @@ class TestExport(unittest.TestCase):
         self.assertIn("Export default pages", browser.contents)
         self.assertIn("Export object positions", browser.contents)
         # browser.getControl(name="portal_type").value = ["Document"]
+
+    def test_export_members(self):
+        browser = self.open_page("@@export_members")
+        data = json.loads(browser.contents)
+        self.assertIn("groups", data.keys())
+        self.assertIn("members", data.keys())
+
+        # Check groups.
+        groups = data["groups"]
+        groupids = [group["groupid"] for group in groups]
+        self.assertIn("Administrators", groupids)
+        self.assertIn("Reviewers", groupids)
+        self.assertIn("Site Administrators", groupids)
+
+        # Check members.
+        members = data["members"]
+        membernames = [member["username"] for member in members]
+        self.assertIn(TEST_USER_ID, membernames)
+        for member in members:
+            if member["username"] == TEST_USER_ID:
+                self.assertTrue(member["roles"], ["Member"])

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport.testing import COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING  # noqa: E501
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.testing import z2
+
+import unittest
+
+
+class TestExport(unittest.TestCase):
+    """Test that we can export."""
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def open_page(self, page):
+        """Create a testbrowser, open a page, return the browser."""
+        browser = z2.Browser(self.layer["app"])
+        browser.handleErrors = False
+        browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        url = "/".join([self.layer["portal"].absolute_url(), page])
+        browser.open(url)
+        return browser
+
+    def test_export_content_page(self):
+        # Simply test that some text is on the page.
+        browser = self.open_page("@@export_content")
+        self.assertIn("Export content using plone.restapi", browser.contents)
+        self.assertIn("Export relations", browser.contents)
+        self.assertIn("Export translations", browser.contents)
+        self.assertIn("Export members", browser.contents)
+        self.assertIn("Export local roles", browser.contents)
+        self.assertIn("Export default pages", browser.contents)
+        self.assertIn("Export object positions", browser.contents)
+        # browser.getControl(name="portal_type").value = ["Document"]

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -10,12 +10,17 @@ from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
 
 import json
-import tempfile
+import six
 import transaction
 import unittest
 
 
-class TestExport(unittest.TestCase):
+# TODO: change this to skip the tests on Plone 5.1 and lower.
+# Python 2 on 5.2 should be fine, but currently it gives an error when
+# importing the modified date:
+# ValueError: 'z' is a bad directive in format '%Y-%m-%dT%H:%M:%S%z'
+@unittest.skipIf(six.PY2, "Import is only supported on Python 3 for the moment")
+class TestImport(unittest.TestCase):
     """Test that we can export."""
 
     layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport.testing import (
+    COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,  # noqa: E501,,
+)
+from plone import api
+from plone.app.testing import login
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.testing import z2
+
+import json
+import tempfile
+import transaction
+import unittest
+
+
+class TestExport(unittest.TestCase):
+    """Test that we can export."""
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def open_page(self, page):
+        """Create a testbrowser, open a page, return the browser."""
+        browser = z2.Browser(self.layer["app"])
+        browser.handleErrors = False
+        browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        url = "/".join([self.layer["portal"].absolute_url(), page])
+        browser.open(url)
+        return browser
+
+    def test_import_content_page(self):
+        # Simply test that some text is on the page.
+        browser = self.open_page("@@import_content")
+        # Let's compare lowercase.
+        lower_contents = browser.contents.lower()
+        self.assertIn("import content", lower_contents)
+        self.assertIn("import relations", lower_contents)
+        self.assertIn("import translations", lower_contents)
+        self.assertIn("import members", lower_contents)
+        self.assertIn("import local roles", lower_contents)
+        self.assertIn("import default pages", lower_contents)
+        self.assertIn("import object positions", lower_contents)
+
+    def test_import_content_document(self):
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        doc = api.content.create(
+            container=portal, type="Document", id="doc1", title="Document 1"
+        )
+        transaction.commit()
+
+        # Now export it.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = ["Document"]
+        browser.getControl("Export selected type").click()
+        raw_data = browser.contents
+
+        # Remove the added content.
+        api.content.delete(doc)
+        transaction.commit()
+        self.assertNotIn("doc1", portal.contentIds())
+
+        # Now import it.
+        browser = self.open_page("@@import_content")
+        upload = browser.getControl(name="jsonfile")
+        upload.add_file(raw_data, "application/json", "documents.json")
+        browser.getForm(action="@@import_content").submit()
+        # Note: when we upload the data with filename foo.json,
+        # the status message will be "Imported 1 foo".
+        self.assertIn("Imported 1 documents", browser.contents)
+
+        # The document should be back.
+        self.assertIn("doc1", portal.contentIds())
+        new_doc = portal["doc1"]
+        self.assertEqual(new_doc.Title(), "Document 1")

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from App.config import getConfiguration
 from collective.exportimport.testing import (
     COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,  # noqa: E501,,
 )
@@ -10,7 +11,10 @@ from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
 
 import json
+import os
+import shutil
 import six
+import tempfile
 import transaction
 import unittest
 
@@ -24,6 +28,21 @@ class TestImport(unittest.TestCase):
     """Test that we can export."""
 
     layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set a client home for our import directory.
+        # Usually this is buildout-dir/var/instance.
+        # In tests it is somewhere in an egg, which is not helpful.
+        cfg = getConfiguration()
+        self.orig_clienthome = cfg.clienthome
+        self.new_clienthome = tempfile.mkdtemp(suffix=".clienthome")
+        os.mkdir(os.path.join(self.new_clienthome, "import"))
+        cfg.clienthome = self.new_clienthome
+
+    def tearDown(self):
+        cfg = getConfiguration()
+        cfg.clienthome = self.orig_clienthome
+        shutil.rmtree(self.new_clienthome)
 
     def open_page(self, page):
         """Create a testbrowser, open a page, return the browser."""
@@ -74,13 +93,56 @@ class TestImport(unittest.TestCase):
         # Now import it.
         browser = self.open_page("@@import_content")
         upload = browser.getControl(name="jsonfile")
-        upload.add_file(raw_data, "application/json", "documents.json")
+        upload.add_file(raw_data, "application/json", "Document.json")
         browser.getForm(action="@@import_content").submit()
-        # Note: when we upload the data with filename foo.json,
-        # the status message will be "Imported 1 foo".
-        self.assertIn("Imported 1 documents", browser.contents)
+        self.assertIn("Imported 1 Document", browser.contents)
 
         # The document should be back.
         self.assertIn("doc1", portal.contentIds())
         new_doc = portal["doc1"]
         self.assertEqual(new_doc.Title(), "Document 1")
+        self.assertEqual(new_doc.portal_type, "Document")
+
+    def test_import_content_from_server_file(self):
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        doc = api.content.create(
+            container=portal, type="Document", id="doc1", title="Document 1"
+        )
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = ["Document"]
+        browser.getControl("Save to file on server").click()
+        browser.getControl("Export selected type").click()
+        self.assertIn("Exported 1 Document as Document.json", browser.contents)
+        self.assertIn(self.new_clienthome, browser.contents)
+
+        # Move the exported file to the import directory.
+        export_path = os.path.join(self.new_clienthome, "Document.json")
+        import_path = os.path.join(self.new_clienthome, "import", "Document.json")
+        self.assertTrue(os.path.isfile(export_path))
+        self.assertFalse(os.path.exists(import_path))
+        shutil.move(export_path, import_path)
+        self.assertTrue(os.path.isfile(import_path))
+
+        # Remove the added content.
+        api.content.delete(doc)
+        transaction.commit()
+        self.assertNotIn("doc1", portal.contentIds())
+
+        # Now import it.
+        browser = self.open_page("@@import_content")
+        server_file = browser.getControl(name="server_file")
+        server_file.value = ["Document.json"]
+        browser.getForm(action="@@import_content").submit()
+        self.assertIn("Imported 1 Document", browser.contents)
+
+        # The document should be back.
+        self.assertIn("doc1", portal.contentIds())
+        new_doc = portal["doc1"]
+        self.assertEqual(new_doc.Title(), "Document 1")
+        self.assertEqual(new_doc.portal_type, "Document")

--- a/src/collective/exportimport/tests/test_setup.py
+++ b/src/collective/exportimport/tests/test_setup.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Setup tests for this package."""
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from collective.exportimport.testing import COLLECTIVE_EXPORTIMPORT_INTEGRATION_TESTING  # noqa: E501
+
+import unittest
+
+
+try:
+    from Products.CMFPlone.utils import get_installer
+except ImportError:
+    get_installer = None
+
+
+class TestSetup(unittest.TestCase):
+    """Test that collective.exportimport is properly installed."""
+
+    layer = COLLECTIVE_EXPORTIMPORT_INTEGRATION_TESTING
+
+    def setUp(self):
+        """Custom shared utility setup for tests."""
+        self.portal = self.layer['portal']
+        if get_installer:
+            self.installer = get_installer(self.portal, self.layer['request'])
+        else:
+            self.installer = api.portal.get_tool('portal_quickinstaller')
+
+    def test_restapi_installed(self):
+        """Test if restapi is installed, because we need it."""
+        self.assertTrue(self.installer.isProductInstalled(
+            'plone.restapi'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+minversion = 3.18
+envlist =
+    plone52-py{27,38}
+
+[testenv]
+# We do not install with pip, but with buildout:
+usedevelop = false
+skip_install = true
+deps =
+    -r requirements.txt
+commands_pre =
+    {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+commands =
+    {envbindir}/test


### PR DESCRIPTION
I added initial tests for exporting and importing one document, and for exporting members.
Locally you can run `tox -p auto` to run the tests for the two environments I have defined: Plone 5.2 on Python 2.7 and on 3.8.
On 2.7 I skip the import content test for the moment, because it fails with a date format error. See comment in the code. I think we know about that error already.
I would want to run the export tests on 4.3 as well, but that is left as an exercise for later.

This PR also contains a few small fixes that I discovered while getting the buildout and instance running (for example include CMFCore so we can use the Manage Portal permission in zcml) and the tests running (mainly a possible json/bytes error while exporting the test member).

Not perfect, but it is a start.