### PR TITLE
Add option to import file from server.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add option to import file from server.
+  [maurits]
 
 
 1.0 (2021-04-27)

--- a/src/collective/exportimport/templates/import_content.pt
+++ b/src/collective/exportimport/templates/import_content.pt
@@ -17,6 +17,23 @@
                 <input type="file" name="jsonfile"/><br/>
             </div>
 
+            <tal:block define="server_files view/server_files">
+              <p i18n:translate="server_paths_list">Or you can choose a file that is already uploaded on the server in one of these paths:</p>
+              <ul>
+                <li tal:repeat="path view/import_paths"><code tal:content="path" /></li>
+              </ul>
+              <p tal:condition="not:server_files" i18n:translate="">No files found.</p>
+              <div class="field mb-3" tal:condition="server_files">
+                <label for="server_file" i18n:translate="">File on server to import:</label>
+                <br />
+                <select id="server_file" name="server_file">
+                  <option selected="" value="" title="" i18n:translate="">Choose one</option>
+                  <option tal:repeat="filename server_files" tal:content="filename" tal:attributes="value filename">
+                  </option>
+                </select>
+              </div>
+            </tal:block>
+
             <div class="field">
               <label>
                 <input

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from App.config import getConfiguration
 from collective.exportimport.testing import (
     COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,  # noqa: E501,,
 )
@@ -10,7 +11,10 @@ from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
 
 import json
+import os
+import shutil
 import six
+import tempfile
 import transaction
 import unittest
 
@@ -24,6 +28,21 @@ class TestImport(unittest.TestCase):
     """Test that we can export."""
 
     layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set a client home for our import directory.
+        # Usually this is buildout-dir/var/instance.
+        # In tests it is somewhere in an egg, which is not helpful.
+        cfg = getConfiguration()
+        self.orig_clienthome = cfg.clienthome
+        self.new_clienthome = tempfile.mkdtemp(suffix=".clienthome")
+        os.mkdir(os.path.join(self.new_clienthome, "import"))
+        cfg.clienthome = self.new_clienthome
+
+    def tearDown(self):
+        cfg = getConfiguration()
+        cfg.clienthome = self.orig_clienthome
+        shutil.rmtree(self.new_clienthome)
 
     def open_page(self, page):
         """Create a testbrowser, open a page, return the browser."""
@@ -74,13 +93,56 @@ class TestImport(unittest.TestCase):
         # Now import it.
         browser = self.open_page("@@import_content")
         upload = browser.getControl(name="jsonfile")
-        upload.add_file(raw_data, "application/json", "documents.json")
+        upload.add_file(raw_data, "application/json", "Document.json")
         browser.getForm(action="@@import_content").submit()
-        # Note: when we upload the data with filename foo.json,
-        # the status message will be "Imported 1 foo".
-        self.assertIn("Imported 1 documents", browser.contents)
+        self.assertIn("Imported 1 Document", browser.contents)
 
         # The document should be back.
         self.assertIn("doc1", portal.contentIds())
         new_doc = portal["doc1"]
         self.assertEqual(new_doc.Title(), "Document 1")
+        self.assertEqual(new_doc.portal_type, "Document")
+
+    def test_import_content_from_server_file(self):
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        doc = api.content.create(
+            container=portal, type="Document", id="doc1", title="Document 1"
+        )
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = ["Document"]
+        browser.getControl("Save to file on server").click()
+        browser.getControl("Export selected type").click()
+        self.assertIn("Exported 1 Document as Document.json", browser.contents)
+        self.assertIn(self.new_clienthome, browser.contents)
+
+        # Move the exported file to the import directory.
+        export_path = os.path.join(self.new_clienthome, "Document.json")
+        import_path = os.path.join(self.new_clienthome, "import", "Document.json")
+        self.assertTrue(os.path.isfile(export_path))
+        self.assertFalse(os.path.exists(import_path))
+        shutil.move(export_path, import_path)
+        self.assertTrue(os.path.isfile(import_path))
+
+        # Remove the added content.
+        api.content.delete(doc)
+        transaction.commit()
+        self.assertNotIn("doc1", portal.contentIds())
+
+        # Now import it.
+        browser = self.open_page("@@import_content")
+        server_file = browser.getControl(name="server_file")
+        server_file.value = ["Document.json"]
+        browser.getForm(action="@@import_content").submit()
+        self.assertIn("Imported 1 Document", browser.contents)
+
+        # The document should be back.
+        self.assertIn("doc1", portal.contentIds())
+        new_doc = portal["doc1"]
+        self.assertEqual(new_doc.Title(), "Document 1")
+        self.assertEqual(new_doc.portal_type, "Document")


### PR DESCRIPTION
We look in the same places that the zexp import code looks, which means the import directory in the client home and instance home.

This builds on the branch my PR #13 which introduces tests.
TODO: actually add a test for this new option, which is why I mark this as a Draft PR.
But it works for me when I try it manually (Plone 5.2, Py 3.8).