### PR TITLE
Test on more Plone and Python versions.

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -1,0 +1,42 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+
+show-picked-versions = true
+extensions =
+    mr.developer
+
+parts =
+    instance
+    omelette
+    releaser
+    test
+
+develop = .
+package-name = collective.exportimport
+package-extras = [test]
+
+[instance]
+recipe = plone.recipe.zope2instance
+user = admin:admin
+http-address = 8080
+environment-vars =
+    zope_i18n_compile_mo_files true
+eggs =
+    Plone
+    Pillow
+    collective.exportimport
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${instance:eggs}
+
+[releaser]
+recipe = zc.recipe.egg
+eggs = zest.releaser[recommended]
+
+[versions]
+# Don't use a released version of collective.exportimport
+collective.exportimport =
+hurry.filesize = 0.9

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,42 +1,4 @@
 [buildout]
-extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
-show-picked-versions = true
-extensions =
-    mr.developer
-
-parts =
+extends = test-5.2.x.cfg
+parts +=
     instance
-    omelette
-    releaser
-    test
-
-develop = .
-package-name = collective.exportimport
-package-extras = [test]
-
-[instance]
-recipe = plone.recipe.zope2instance
-user = admin:admin
-http-address = 8080
-environment-vars =
-    zope_i18n_compile_mo_files true
-eggs =
-    Plone
-    Pillow
-    collective.exportimport
-
-[omelette]
-recipe = collective.recipe.omelette
-eggs = ${instance:eggs}
-
-[releaser]
-recipe = zc.recipe.egg
-eggs = zest.releaser[recommended]
-
-[versions]
-# Don't use a released version of collective.exportimport
-collective.exportimport =
-hurry.filesize = 0.9

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -13,7 +13,7 @@ from plone.testing import z2
 import json
 import os
 import shutil
-import six
+import sys
 import tempfile
 import transaction
 import unittest
@@ -23,7 +23,8 @@ import unittest
 # Python 2 on 5.2 should be fine, but currently it gives an error when
 # importing the modified date:
 # ValueError: 'z' is a bad directive in format '%Y-%m-%dT%H:%M:%S%z'
-@unittest.skipIf(six.PY2, "Import is only supported on Python 3 for the moment")
+# Ah, and we have the same error on Python 3.6.
+@unittest.skipIf(sys.version_info[:2] < (3, 7), "Import is only supported on Python 3.7+ for the moment")
 class TestImport(unittest.TestCase):
     """Test that we can export."""
 

--- a/test-4.3.x.cfg
+++ b/test-4.3.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-4.x.cfg
+    base.cfg

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.0.x.cfg
+    base.cfg
+
+[versions]
+# Maybe just a problem with 3.3.0 on Maurits' Mac:
+Pillow = 3.3.3

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.1.x.cfg
+    base.cfg
+

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
+    base.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 minversion = 3.18
 envlist =
-    plone52-py{27,38}
+    plone43-py27
+    plone50-py27
+    plone51-py27
+    plone52-py{27,36,37,38}
 
 [testenv]
 # We do not install with pip, but with buildout:
@@ -10,6 +13,9 @@ skip_install = true
 deps =
     -r requirements.txt
 commands_pre =
-    {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone43: {envbindir}/buildout -nc {toxinidir}/test-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone50: {envbindir}/buildout -nc {toxinidir}/test-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone51: {envbindir}/buildout -nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone52: {envbindir}/buildout -nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
     {envbindir}/test


### PR DESCRIPTION
The import tests are only supported on Plone 5.2 Python 3.7/3.8.
On Python 3.6 and lower I skip the import tests because of the datetime problem from issue #10.
