### PR TITLE
Add export and import tests for default pages and ordering

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -1,0 +1,42 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+
+show-picked-versions = true
+extensions =
+    mr.developer
+
+parts =
+    instance
+    omelette
+    releaser
+    test
+
+develop = .
+package-name = collective.exportimport
+package-extras = [test]
+
+[instance]
+recipe = plone.recipe.zope2instance
+user = admin:admin
+http-address = 8080
+environment-vars =
+    zope_i18n_compile_mo_files true
+eggs =
+    Plone
+    Pillow
+    collective.exportimport
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${instance:eggs}
+
+[releaser]
+recipe = zc.recipe.egg
+eggs = zest.releaser[recommended]
+
+[versions]
+# Don't use a released version of collective.exportimport
+collective.exportimport =
+hurry.filesize = 0.9

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,42 +1,4 @@
 [buildout]
-extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
-show-picked-versions = true
-extensions =
-    mr.developer
-
-parts =
+extends = test-5.2.x.cfg
+parts +=
     instance
-    omelette
-    releaser
-    test
-
-develop = .
-package-name = collective.exportimport
-package-extras = [test]
-
-[instance]
-recipe = plone.recipe.zope2instance
-user = admin:admin
-http-address = 8080
-environment-vars =
-    zope_i18n_compile_mo_files true
-eggs =
-    Plone
-    Pillow
-    collective.exportimport
-
-[omelette]
-recipe = collective.recipe.omelette
-eggs = ${instance:eggs}
-
-[releaser]
-recipe = zc.recipe.egg
-eggs = zest.releaser[recommended]
-
-[versions]
-# Don't use a released version of collective.exportimport
-collective.exportimport =
-hurry.filesize = 0.9

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -8,7 +8,7 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-from plone.testing import z2
+from plone.testing import zope
 
 import json
 import transaction
@@ -22,7 +22,7 @@ class TestExport(unittest.TestCase):
 
     def open_page(self, page):
         """Create a testbrowser, open a page, return the browser."""
-        browser = z2.Browser(self.layer["app"])
+        browser = zope.Browser(self.layer["app"])
         browser.handleErrors = False
         browser.addHeader(
             "Authorization",

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -93,3 +93,29 @@ class TestExport(unittest.TestCase):
         for member in members:
             if member["username"] == TEST_USER_ID:
                 self.assertTrue(member["roles"], ["Member"])
+
+    def test_export_defaultpages_empty(self):
+        browser = self.open_page("@@export_defaultpages")
+        data = json.loads(browser.contents)
+        self.assertListEqual(data, [])
+
+    def test_export_defaultpages(self):
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        folder1 = api.content.create(
+            container=portal, type="Folder", id="folder1", title="Folder 1"
+        )
+        doc1 = api.content.create(
+            container=folder1, type="Document", id="doc1", title="Document 1"
+        )
+        folder1._setProperty("default_page", "doc1")
+        transaction.commit()
+
+        browser = self.open_page("@@export_defaultpages")
+        data = json.loads(browser.contents)
+        self.assertListEqual(
+            data,
+            [{'default_page': 'doc1', 'uuid': folder1.UID()}],
+        )

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -9,7 +9,7 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-from plone.testing import z2
+from plone.testing import zope
 
 import json
 import os
@@ -48,7 +48,7 @@ class TestImport(unittest.TestCase):
 
     def open_page(self, page):
         """Create a testbrowser, open a page, return the browser."""
-        browser = z2.Browser(self.layer["app"])
+        browser = zope.Browser(self.layer["app"])
         browser.handleErrors = False
         browser.addHeader(
             "Authorization",

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -13,7 +13,7 @@ from plone.testing import z2
 import json
 import os
 import shutil
-import six
+import sys
 import tempfile
 import transaction
 import unittest
@@ -23,7 +23,8 @@ import unittest
 # Python 2 on 5.2 should be fine, but currently it gives an error when
 # importing the modified date:
 # ValueError: 'z' is a bad directive in format '%Y-%m-%dT%H:%M:%S%z'
-@unittest.skipIf(six.PY2, "Import is only supported on Python 3 for the moment")
+# Ah, and we have the same error on Python 3.6.
+@unittest.skipIf(sys.version_info[:2] < (3, 7), "Import is only supported on Python 3.7+ for the moment")
 class TestImport(unittest.TestCase):
     """Test that we can export."""
 

--- a/src/collective/exportimport/tests/test_setup.py
+++ b/src/collective/exportimport/tests/test_setup.py
@@ -19,15 +19,11 @@ class TestSetup(unittest.TestCase):
 
     layer = COLLECTIVE_EXPORTIMPORT_INTEGRATION_TESTING
 
-    def setUp(self):
-        """Custom shared utility setup for tests."""
-        self.portal = self.layer['portal']
-        if get_installer:
-            self.installer = get_installer(self.portal, self.layer['request'])
-        else:
-            self.installer = api.portal.get_tool('portal_quickinstaller')
-
     def test_restapi_installed(self):
         """Test if restapi is installed, because we need it."""
-        self.assertTrue(self.installer.isProductInstalled(
-            'plone.restapi'))
+        if get_installer:
+            installer = get_installer(self.layer['portal'], self.layer['request'])
+            self.assertTrue(installer.is_product_installed('plone.restapi'))
+        else:
+            installer = api.portal.get_tool('portal_quickinstaller')
+            self.assertTrue(installer.isProductInstalled('plone.restapi'))

--- a/test-4.3.x.cfg
+++ b/test-4.3.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-4.x.cfg
+    base.cfg

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.0.x.cfg
+    base.cfg
+
+[versions]
+# Maybe just a problem with 3.3.0 on Maurits' Mac:
+Pillow = 3.3.3

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.1.x.cfg
+    base.cfg
+

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
+    base.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ skip_install = true
 deps =
     -r requirements.txt
 commands_pre =
-    plone43: {envbindir}/buildout -nc {toxinidir}/test-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
-    plone50: {envbindir}/buildout -nc {toxinidir}/test-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
-    plone51: {envbindir}/buildout -nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
-    plone52: {envbindir}/buildout -nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone43: {envbindir}/buildout -Nc {toxinidir}/test-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone50: {envbindir}/buildout -Nc {toxinidir}/test-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone51: {envbindir}/buildout -Nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone52: {envbindir}/buildout -Nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
     {envbindir}/test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 minversion = 3.18
 envlist =
-    plone52-py{27,38}
+    plone43-py27
+    plone50-py27
+    plone51-py27
+    plone52-py{27,36,37,38}
 
 [testenv]
 # We do not install with pip, but with buildout:
@@ -10,6 +13,9 @@ skip_install = true
 deps =
     -r requirements.txt
 commands_pre =
-    {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone43: {envbindir}/buildout -nc {toxinidir}/test-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone50: {envbindir}/buildout -nc {toxinidir}/test-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone51: {envbindir}/buildout -nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone52: {envbindir}/buildout -nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
     {envbindir}/test


### PR DESCRIPTION
This builds on and includes the small changes from my PR #16, for testing on more Plone/Python versions.

