### PR TITLE
GitHub Actions: run all tox environments.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,12 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
+        - ["2.7",   "plone43-py27"]
+        - ["2.7",   "plone50-py27"]
+        - ["2.7",   "plone51-py27"]
         - ["2.7",   "plone52-py27"]
+        - ["3.6",   "plone52-py36"]
+        - ["3.7",   "plone52-py37"]
         - ["3.8",   "plone52-py38"]
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}


### PR DESCRIPTION
Apparently I forgot to update this.
Locally `tox -p auto` succeeds.