### PR TITLE
Fix use in Plone 4.3 with dexterity but without z3c.relationfield.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Changelog
 - Fix use in Plone 4.3 without dexterity, zc.relation or plone.app.contenttypes.
   [pbauer]
 
+- Fix use in Plone 4.3 with dexterity but without z3c.relationfield.
+  [maurits]
+
+
 1.0 (2021-04-27)
 ----------------
 

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -87,6 +87,8 @@
   <adapter factory=".serializer.FileFieldSerializerWithBlobs" />
   <adapter factory=".serializer.ImageFieldSerializerWithBlobs" />
   <adapter factory=".serializer.RichttextFieldSerializerWithRawText" />
+  <adapter zcml:condition="installed z3c.relationfield"
+      factory=".export_content.relationvalue_converter_uuid" />
 
   <browser:page
       name="exportimport_links"


### PR DESCRIPTION
You get this for example in Plone 4.3 with only collective.easyform.
Partial traceback when visiting the export-content page:

```
  Module collective.exportimport.export_content, line 218, in portal_types
AttributeError: 'NoneType' object has no attribute 'providedBy'
```

That is [this line](https://github.com/collective/collective.exportimport/blob/134c18da5d32bc11a986db87d5c458eea7ac2684/src/collective/exportimport/export_content.py#L218).

Also, registered the [`relationvalue_converter_uuid`](https://github.com/collective/collective.exportimport/blob/134c18da5d32bc11a986db87d5c458eea7ac2684/src/collective/exportimport/export_content.py#L344-L346) serializer/adapter. It had an `@adapter` and `@implementer` but no zcml was registering it.