### PR TITLE
Fix installation using pip.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,9 @@ Changelog
 - Fix installation with older versions of setuptools (#35)
   [pbauer]
 
+- Fix installation using pip (#36)
+  [ericof]
+
 
 1.0 (2021-04-27)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=install_requires,
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ long_description = "\n\n".join(
     ]
 )
 
-python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
-
-
 install_requires = [
     "setuptools",
     "plone.api >= 1.8.4",
@@ -71,7 +68,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=python_requires,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
     install_requires=install_requires,
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ long_description = "\n\n".join(
     ]
 )
 
+python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+
+
 install_requires = [
     "setuptools",
     "plone.api >= 1.8.4",
@@ -68,7 +71,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires=python_requires,
     install_requires=install_requires,
     extras_require={
         "test": [


### PR DESCRIPTION
The package now supports installation with pip (`pip install collective.exportimport`) for the following Python versions:

- Python 2.7.x
- Python >= 3.7.x

Fixes #36 