### PR TITLE
Use the correct Plone versions when testing.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2
+    - name: Install lxml dev libraries
+      # Needed to avoid error on Plone 5.0.
+      # Error: Please make sure the libxml2 and libxslt development packages are installed.
+      run: sudo apt-get install libxml2-dev libxslt1-dev
+      if: matrix.config[1] == 'plone50-py27'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 jobs:
   build:
     strategy:

--- a/base.cfg
+++ b/base.cfg
@@ -1,6 +1,6 @@
 [buildout]
+index = https://pypi.org/simple/
 extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
 
 show-picked-versions = true
@@ -40,3 +40,13 @@ eggs = zest.releaser[recommended]
 # Don't use a released version of collective.exportimport
 collective.exportimport =
 hurry.filesize = 0.9
+pyjwt = 1.7.1
+# For Buildout related packages, it is easiest to keep them at the same version for all environments.
+# Keep these in sync with requirements.txt please:
+setuptools = 42.0.2
+wheel = 0.36.2
+zc.buildout = 2.13.4
+
+[versions:python27]
+# Last pyrsistent version that is python 2 compatible:
+pyrsistent = 0.15.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,0 @@
--c constraints_plone52.txt

--- a/constraints_plone52.txt
+++ b/constraints_plone52.txt
@@ -1,3 +1,0 @@
--c https://dist.plone.org/release/5.2-latest/requirements.txt
-# setuptools==40.2.0
-# zc.buildout==2.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
--c constraints.txt
-setuptools
-zc.buildout
+# For Buildout related packages, it is easiest to keep them at the same version for all environments.
+# Keep these in sync with base.cfg please:
+setuptools==42.0.2
+zc.buildout==2.13.4
+wheel==0.36.2

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
             "plone.app.testing",
             # needed as test dependency of plone.app.event:
             "plone.app.robotframework",
+            "plone.app.contenttypes",
         ],
     },
     entry_points="""

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -8,7 +8,11 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-from plone.testing import zope
+try:
+    from plone.testing import zope
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
 
 import json
 import transaction
@@ -62,7 +66,13 @@ class TestExport(unittest.TestCase):
         self.assertIn("Document", portal_type.options)
         self.assertNotIn("Folder", portal_type.options)
         portal_type.value = ["Document"]
-        browser.getControl("Export selected type").click()
+        try:
+            # Plone 5.2
+            browser.getControl("Export selected type").click()
+        except LookupError:
+            # Plone 5.1 and lower
+            browser.getForm(index=1).submit()
+            # But this does not help, because browser.contents then is empty...
 
         # We should have gotten json.
         data = json.loads(browser.contents)

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -8,21 +8,51 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-try:
-    from plone.testing import zope
-except ImportError:
-    # BBB for plone.testing 4
-    from plone.testing import z2 as zope
 
 import json
 import transaction
 import unittest
+
+try:
+    from plone.testing import zope
+    OLD_ZOPE_TESTBROWSER = False
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
+    from ZPublisher.HTTPResponse import HTTPResponse
+    OLD_ZOPE_TESTBROWSER = True
+
+
+DATA = []
+
+
+def write(self, data):
+    """Override for HTTPResponse.write.
+
+    In Zope 2 (Plone 4.3-5.1) in tests, when we export content to download it,
+    the resulting browser.contents is empty, instead of containing json.
+    This is an ugly hack to capture the data that should be available.
+    I tried a few other ways, but failed.
+    """
+    self._orig_write(data)
+    DATA.append(data)
 
 
 class TestExport(unittest.TestCase):
     """Test that we can export."""
 
     layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        if OLD_ZOPE_TESTBROWSER:
+            # patch HTTPResponse so we can get an attachment
+            HTTPResponse._orig_write = HTTPResponse.write
+            HTTPResponse.write = write
+
+    def tearDown(self):
+        if OLD_ZOPE_TESTBROWSER:
+            # undo patch
+            HTTPResponse.write = HTTPResponse._orig_write
 
     def open_page(self, page):
         """Create a testbrowser, open a page, return the browser."""
@@ -69,13 +99,15 @@ class TestExport(unittest.TestCase):
         try:
             # Plone 5.2
             browser.getControl("Export selected type").click()
+            contents = browser.contents
         except LookupError:
             # Plone 5.1 and lower
             browser.getForm(index=1).submit()
-            # But this does not help, because browser.contents then is empty...
+            if not browser.contents:
+                contents = DATA[-1]
 
         # We should have gotten json.
-        data = json.loads(browser.contents)
+        data = json.loads(contents)
         self.assertEqual(len(data), 1)
 
         # Check a few important keys.
@@ -101,10 +133,17 @@ class TestExport(unittest.TestCase):
         self.assertIn("Collection", portal_type.options)
         self.assertNotIn("Folder", portal_type.options)
         portal_type.value = ["Collection"]
-        browser.getControl("Export selected type").click()
+        try:
+            browser.getControl("Export selected type").click()
+            contents = browser.contents
+        except LookupError:
+            # Plone 5.1 and lower
+            browser.getForm(index=1).submit()
+            if not browser.contents:
+                contents = DATA[-1]
 
         # We should have gotten json.
-        data = json.loads(browser.contents)
+        data = json.loads(contents)
         self.assertEqual(len(data), 1)
 
         # Check a few important keys.
@@ -116,7 +155,10 @@ class TestExport(unittest.TestCase):
     def test_export_members(self):
         browser = self.open_page("@@export_members")
         browser.getForm(action='@@export_members').submit(name='form.submitted')
-        data = json.loads(browser.contents)
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
         self.assertIn("groups", data.keys())
         self.assertIn("members", data.keys())
 
@@ -138,7 +180,10 @@ class TestExport(unittest.TestCase):
     def test_export_defaultpages_empty(self):
         browser = self.open_page("@@export_defaultpages")
         browser.getForm(action='@@export_defaultpages').submit(name='form.submitted')
-        data = json.loads(browser.contents)
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
         self.assertListEqual(data, [])
 
     def test_export_defaultpages(self):
@@ -158,7 +203,10 @@ class TestExport(unittest.TestCase):
 
         browser = self.open_page("@@export_defaultpages")
         browser.getForm(action='@@export_defaultpages').submit(name='form.submitted')
-        data = json.loads(browser.contents)
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
         self.assertListEqual(
             data,
             [{'default_page': 'doc1', 'uuid': folder1.UID()}],
@@ -186,7 +234,10 @@ class TestExport(unittest.TestCase):
         # Export.
         browser = self.open_page("@@export_ordering")
         browser.getForm(action='@@export_ordering').submit(name='form.submitted')
-        data = json.loads(browser.contents)
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
 
         # Turn the list into a dict for easier searching and comparing.
         data_uuid2order = {}
@@ -211,7 +262,10 @@ class TestExport(unittest.TestCase):
         # Export and check.
         browser = self.open_page("@@export_ordering")
         browser.getForm(action='@@export_ordering').submit(name='form.submitted')
-        data = json.loads(browser.contents)
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
         data_uuid2order = {}
         for item in data:
             data_uuid2order[item["uuid"]] = item["order"]

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -9,7 +9,11 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-from plone.testing import zope
+try:
+    from plone.testing import zope
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
 
 import json
 import os

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -6,3 +6,5 @@ extends =
 [versions]
 # Maybe just a problem with 3.3.0 on Maurits' Mac:
 Pillow = 3.3.3
+# plone.restapi now requires 'plone.schema>=1.2.1', but Plone 5.0 pins it to 1.1.0.
+plone.schema = 1.2.1


### PR DESCRIPTION
All tox/GHA environments were testing Plone 5.2.
Looks like I made the mistake in May.

Some tests on 5.1 and lower fail now... Might just be differences in how to call the zope test browser.