### PR TITLE
Fixed creating missing folder structure.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,12 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Fixed creating missing folder structure.  [maurits]
+
 - Export portlets.
   [pbauer]
 
-- Export content and write to file using a generator/yield. This avoids memory ballooning to the size of the exported file. 
+- Export content and write to file using a generator/yield. This avoids memory ballooning to the size of the exported file.
   [fredvd]
 
 


### PR DESCRIPTION
This fixes errors like this:

    zExceptions.BadRequest: The id "plone" is reserved.

I found this when exporting Folders and Documents using the `support_trees` branch, and then importing them in a fresh site. Some of the Documents were not in Folders, but in a different portal_type, so a folder structure was missing.