### PR TITLE
Support blob paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,13 +11,8 @@ Changelog
 - Export and import complete sites or content trees with configurable types, depth and path (#40).
   [pbauer]
 
-- Fixed creating missing folder structure (#45).
-  [maurits]
 - Added option to export blobs as blob paths.
   [pbauer, maurits]
-
-- Added option to export all content in a tree.
-  [pbauer]
 
 - Fixed creating missing folder structure.  [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ Changelog
 
 - Fixed creating missing folder structure (#45).
   [maurits]
+- Added option to export blobs as blob paths.
+  [pbauer, maurits]
+
+- Added option to export all content in a tree.
+  [pbauer]
+
+- Fixed creating missing folder structure.  [maurits]
 
 - Export and import portlets (#39).
   [pbauer]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,10 +11,11 @@ Changelog
 - Export and import complete sites or content trees with configurable types, depth and path (#40).
   [pbauer]
 
-- Added option to export blobs as blob paths.
+- Added option to export blobs as blob paths (#50).
   [pbauer, maurits]
 
-- Fixed creating missing folder structure.  [maurits]
+- Fixed creating missing folder structure (#45).
+  [maurits]
 
 - Export and import portlets (#39).
   [pbauer]

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,13 @@ Exporting and importing large amounts of content can take a while. Export is pre
 * Importing 5000 Documents takes >25 minutes because of versioning.
 * Importing 5000 Documents without versioning takes ~7 minutes.
 
-When exporting large numbers of binary files you will get huge json-files and may run out of memory. Options to export the blob-filepath instead are discussed in https://github.com/collective/collective.exportimport/issues/17.
+When exporting large numbers of blobs (binary files and images) you will get huge json-files and may run out of memory.
+You have various options to deal with this.
+The best way depends on how you are going to import the blobs:
+
+- Export as download urls: small download, but ``collective.exportimport`` cannot import the blobs, so you will need an own import script to download them.
+- Export as base-64 encoded strings: large download, but ``collective.exportimport`` can handle the import.
+- Export as blob paths: small download and ``collective.exportimport`` can handle the import, but you need to copy ``var/blobstorage`` to the Plone Site where you do the import.
 
 
 Customize export and import

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -99,9 +99,15 @@
       factory=".serializer.ATFileFieldSerializerWithBlobs" />
   <adapter zcml:condition="installed plone.app.blob"
       factory=".serializer.ATImageFieldSerializerWithBlobs" />
+  <adapter zcml:condition="installed plone.app.blob"
+      factory=".serializer.ATFileFieldSerializerWithBlobPaths" />
+  <adapter zcml:condition="installed plone.app.blob"
+      factory=".serializer.ATImageFieldSerializerWithBlobPaths" />
 
   <adapter factory=".serializer.FileFieldSerializerWithBlobs" />
+  <adapter factory=".serializer.FileFieldSerializerWithBlobPaths" />
   <adapter factory=".serializer.ImageFieldSerializerWithBlobs" />
+  <adapter factory=".serializer.ImageFieldSerializerWithBlobPaths" />
   <adapter factory=".serializer.RichttextFieldSerializerWithRawText" />
 
   <browser:page

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -3,6 +3,7 @@ from Acquisition import aq_base
 from App.config import getConfiguration
 from collective.exportimport.interfaces import IBase64BlobsMarker
 from collective.exportimport.interfaces import IMigrationMarker
+from collective.exportimport.interfaces import IPathBlobsMarker
 from collective.exportimport.interfaces import IRawRichTextMarker
 from operator import itemgetter
 from plone import api
@@ -98,7 +99,7 @@ class ExportContent(BrowserView):
         portal_type=None,
         path=None,
         depth=-1,
-        include_blobs=False,
+        include_blobs=0,
         download_to_server=False,
         migration=True,
     ):
@@ -123,6 +124,12 @@ class ExportContent(BrowserView):
             ("9", "9"),
             ("10", "10"),
         )
+        self.include_blobs = int(include_blobs)
+        self.include_blobs_options = (
+            ("0", "as download urls (default)"),
+            ("1", "as base-64 encoded strings"),
+            ("2", "as blob paths"),
+        )
 
         self.update()
 
@@ -133,9 +140,16 @@ class ExportContent(BrowserView):
             api.portal.show_message(u"Select at least one type to export", self.request)
             return self.template()
 
-        if include_blobs:
+        if self.include_blobs == 1:
             # Add marker-interface to request to use our custom serializers
             alsoProvides(self.request, IBase64BlobsMarker)
+        elif self.include_blobs == 2:
+            # Add marker interface to export blob paths
+            alsoProvides(self.request, IPathBlobsMarker)
+        else:
+            # Use the default plone.restapi serializer,
+            # which gives a download url.
+            pass
 
         if self.migration:
             # Add marker-interface to request to use custom serializers
@@ -148,7 +162,7 @@ class ExportContent(BrowserView):
             filename = self.path.split("/")[-1]
         filename = "{}.json".format(filename)
 
-        content_generator = self.export_content(include_blobs=include_blobs)
+        content_generator = self.export_content()
 
         number = 0
         if download_to_server:
@@ -169,9 +183,11 @@ class ExportContent(BrowserView):
             logger.info(msg)
             api.portal.show_message(msg, self.request)
 
-            if include_blobs:
+            if self.include_blobs == 1:
                 # remove marker interface
                 noLongerProvides(self.request, IBase64BlobsMarker)
+            elif self.include_blobs == 2:
+                noLongerProvides(self.request, IPathBlobsMarker)
             self.request.response.redirect(self.request["ACTUAL_URL"])
         else:
             with tempfile.TemporaryFile(mode="w+") as f:
@@ -193,9 +209,11 @@ class ExportContent(BrowserView):
                     "content-disposition",
                     'attachment; filename="{0}"'.format(filename),
                 )
-                if include_blobs:
+                if self.include_blobs == 1:
                     # remove marker interface
                     noLongerProvides(self.request, IBase64BlobsMarker)
+                elif self.include_blobs == 2:
+                    noLongerProvides(self.request, IPathBlobsMarker)
                 f.seek(0)
                 return response.write(safe_bytes(f.read()))
 
@@ -218,7 +236,7 @@ class ExportContent(BrowserView):
         """Overwrite this if you want more control over which content to export."""
         return query
 
-    def export_content(self, include_blobs=False):
+    def export_content(self):
         query = self.build_query()
         catalog = api.portal.get_tool("portal_catalog")
         brains = catalog.unrestrictedSearchResults(**query)

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -99,7 +99,7 @@ class ExportContent(BrowserView):
         portal_type=None,
         path=None,
         depth=-1,
-        include_blobs=0,
+        include_blobs=1,
         download_to_server=False,
         migration=True,
     ):

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -126,7 +126,7 @@ class ExportContent(BrowserView):
         )
         self.include_blobs = int(include_blobs)
         self.include_blobs_options = (
-            ("0", "as download urls (default)"),
+            ("0", "as download urls"),
             ("1", "as base-64 encoded strings"),
             ("2", "as blob paths"),
         )

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from DateTime import DateTime
-from pathlib import Path
 from plone import api
 from plone.api.exc import InvalidParameterError
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -49,13 +48,13 @@ def get_absolute_blob_path(obj, blob_path):
             return blob_path
         return
     if BLOB_HOME:
-        abs_path = Path(BLOB_HOME) / blob_path
+        abs_path = os.path.join(BLOB_HOME, blob_path)
         if os.path.isfile(abs_path):
             return abs_path
     # Try the blobstorage of the current ZODB.
     db = obj._p_jar.db()
     fshelper = db._storage.fshelper
-    abs_path = Path(fshelper.base_dir) / blob_path
+    abs_path = os.path.join(fshelper.base_dir, blob_path)
     if os.path.isfile(abs_path):
         return abs_path
 
@@ -374,8 +373,10 @@ class ImportContent(BrowserView):
                 klass = NamedBlobFile
 
             # Write the field.
+            with open(abs_blob_path, "rb") as myfile:
+                blobdata = myfile.read()
             field_value = klass(
-                data=abs_blob_path.read_bytes(),
+                data=blobdata,
                 contentType=content_type,
                 filename=filename,
             )

--- a/src/collective/exportimport/interfaces.py
+++ b/src/collective/exportimport/interfaces.py
@@ -7,6 +7,10 @@ class IBase64BlobsMarker(Interface):
     """A marker interface to override default serializers."""
 
 
+class IPathBlobsMarker(Interface):
+    """A marker interface to override default serializers."""
+
+
 class IRawRichTextMarker(Interface):
     """A marker interface to override default serializers for Richtext."""
 

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -114,6 +114,15 @@ class RichttextFieldSerializerWithRawText(DefaultFieldSerializer):
             }
 
 
+def get_relative_blob_path(obj, full_path):
+    # Get blob path relative from the blobstorage root.
+    db = obj._p_jar.db()
+    base_dir = db._storage.fshelper.base_dir
+    if not full_path.startswith(base_dir):
+        return full_path
+    return full_path[len(base_dir):]
+
+
 if HAS_AT:
     from OFS.Image import Pdata
     from plone.app.blob.interfaces import IBlobField
@@ -227,8 +236,9 @@ if HAS_AT:
 
     def get_at_blob_path(obj):
         full_path = obj.getBlob().committed()
-        if os.path.exists(full_path):
-            return full_path
+        if not os.path.exists(full_path):
+            return
+        return get_relative_blob_path(obj, full_path)
 
 
     @adapter(IBlobImageField, IBaseObject, IPathBlobsMarker)
@@ -357,8 +367,9 @@ if HAS_AT and HAS_PAC:
 
 def get_dx_blob_path(obj):
     full_path = obj._blob.committed()
-    if os.path.exists(full_path):
-        return full_path
+    if not os.path.exists(full_path):
+        return
+    return get_relative_blob_path(obj, full_path)
 
 
 @adapter(INamedFileField, IDexterityContent, IPathBlobsMarker)

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -226,13 +226,9 @@ if HAS_AT:
 
 
     def get_at_blob_path(obj):
-        oid = obj.getBlob()._p_oid
-        tid = obj._p_serial
-        db = obj._p_jar.db()
-        fshelper = db._storage.fshelper
-        blobfilepath = fshelper.layout.getBlobFilePath(oid, tid)
-        if os.path.exists(blobfilepath):
-            return blobfilepath
+        full_path = obj.getBlob().committed()
+        if os.path.exists(full_path):
+            return full_path
 
 
     @adapter(IBlobImageField, IBaseObject, IPathBlobsMarker)
@@ -360,14 +356,9 @@ if HAS_AT and HAS_PAC:
 
 
 def get_dx_blob_path(obj):
-    oid = obj._blob._p_oid
-    tid = obj._p_serial
-    db = obj._p_jar.db()
-    fshelper = db._storage.fshelper
-    blobfilepath = fshelper.layout.getBlobFilePath(oid, tid)
-    full_path = os.path.join(fshelper.base_dir, blobfilepath)
+    full_path = obj._blob.committed()
     if os.path.exists(full_path):
-        return blobfilepath
+        return full_path
 
 
 @adapter(INamedFileField, IDexterityContent, IPathBlobsMarker)

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -233,13 +233,11 @@ if HAS_AT:
             }
             return json_compatible(result)
 
-
     def get_at_blob_path(obj):
         full_path = obj.getBlob().committed()
         if not os.path.exists(full_path):
             return
         return get_relative_blob_path(obj, full_path)
-
 
     @adapter(IBlobImageField, IBaseObject, IPathBlobsMarker)
     @implementer(IFieldSerializer)
@@ -262,7 +260,6 @@ if HAS_AT:
             }
             return json_compatible(result)
 
-
     @adapter(IBlobField, IBaseObject, IPathBlobsMarker)
     @implementer(IFieldSerializer)
     class ATFileFieldSerializerWithBlobPaths(ATDefaultFieldSerializer):
@@ -284,7 +281,6 @@ if HAS_AT:
                 "blob_path": blobfilepath,
             }
             return json_compatible(result)
-
 
     @adapter(ITextField, IBaseObject, IRawRichTextMarker)
     @implementer(IFieldSerializer)
@@ -395,7 +391,6 @@ class FileFieldSerializerWithBlobPaths(DefaultFieldSerializer):
             "blob_path": blobfilepath,
         }
         return json_compatible(result)
-
 
 
 @adapter(INamedImageField, IDexterityContent, IPathBlobsMarker)

--- a/src/collective/exportimport/templates/export_content.pt
+++ b/src/collective/exportimport/templates/export_content.pt
@@ -56,17 +56,21 @@
             </div>
 
             <div class="field mb-3">
-              <label>
-                <input
-                    type="checkbox"
-                    class="form-check-input"
-                    name="include_blobs:boolean"
-                    id="include_blobs"
-                    value="1"
-                    checked
-                    />
-                Include data from image- and file-fields as base-64 encoded strings?
-              </label>
+              <label for="include_blobs">Include blobs</label>
+              <span class="formHelp">
+                  How should data from image- and file-fields be included?
+              </span>
+              <div class="widget">
+                <select name="include_blobs" class="">
+                  <option value="0"
+                          tal:repeat="current python:view.include_blobs_options"
+                          tal:attributes="value python: current[0];
+                                          selected python:'selected' if int(current[0]) == view.include_blobs else False"
+                          tal:content="python:current[1]">
+                        0
+                  </option>
+                </select>
+              </div>
             </div>
 
             <div class="field mb-3">


### PR DESCRIPTION
This adapts Philips code from issue #17 for exporting and import blobs by just their path.
Works for me in a large export/import from 4.3 to 5.2.
I tried adding a test, see current last commit, but the DemoStorage in the functional test seems to miss the `fshelper` which would be needed to find the actual blobstorage.