### PR TITLE
Read environment variable COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Read environment variable ``COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY``.
+  When set, this is used for storing an export file and getting an import file.
+  This is useful for sharing content between multiple Plone Sites on the same server.
+  [maurits]
+
 - Unescape html entities and line-breaks when importing comments (#43).
   [pbauer]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Read environment variable ``COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY``.
+- Read environment variable ``COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY`` (#51).
   When set, this is used for storing an export file and getting an import file.
   This is useful for sharing content between multiple Plone Sites on the same server.
   [maurits]

--- a/src/collective/exportimport/config.py
+++ b/src/collective/exportimport/config.py
@@ -1,0 +1,11 @@
+import os
+
+
+# Central directory for storing exports and reading imports.
+# Useful when you want to export content from one Plone Site
+# to another on the same server.
+# Or prepare content on your development machine,
+# and copy it to this central directory on the server.
+# When set, this is used instead of for example
+# var/instance/ or var/instance/import/
+CENTRAL_DIRECTORY = os.getenv("COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY", "")

--- a/src/collective/exportimport/config.py
+++ b/src/collective/exportimport/config.py
@@ -8,4 +8,6 @@ import os
 # and copy it to this central directory on the server.
 # When set, this is used instead of for example
 # var/instance/ or var/instance/import/
-CENTRAL_DIRECTORY = os.getenv("COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY", "")
+CENTRAL_DIRECTORY = os.path.expanduser(
+    os.path.expandvars(os.getenv("COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY", ""))
+)

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
 from App.config import getConfiguration
+from collective.exportimport import config
 from collective.exportimport.interfaces import IBase64BlobsMarker
 from collective.exportimport.interfaces import IMigrationMarker
 from collective.exportimport.interfaces import IRawRichTextMarker
@@ -152,8 +153,15 @@ class ExportContent(BrowserView):
 
         number = 0
         if download_to_server:
-            cfg = getConfiguration()
-            filepath = os.path.join(cfg.clienthome, filename)
+            directory = config.CENTRAL_DIRECTORY
+            if directory:
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+                    logger.info("Created central export/import directory %s", directory)
+            else:
+                cfg = getConfiguration()
+                directory = cfg.clienthome
+            filepath = os.path.join(directory, filename)
             with open(filepath, "w") as f:
                 for number, datum in enumerate(content_generator, start=1):
                     if number == 1:

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.exportimport import config
 from datetime import datetime
 from DateTime import DateTime
 from plone import api
@@ -139,6 +140,8 @@ class ImportContent(BrowserView):
             directory = os.path.join(impath, "import")
             listing.append(directory)
         listing.sort()
+        if config.CENTRAL_DIRECTORY:
+            listing.insert(0, config.CENTRAL_DIRECTORY)
         return listing
 
     @property
@@ -148,7 +151,11 @@ class ImportContent(BrowserView):
         for directory in self.import_paths:
             if not os.path.isdir(directory):
                 continue
-            listing += [f for f in os.listdir(directory) if f.endswith(".json")]
+            listing += [
+                f
+                for f in os.listdir(directory)
+                if f.endswith(".json") and f not in listing
+            ]
         listing.sort()
         return listing
 

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -292,6 +292,61 @@ class TestImport(unittest.TestCase):
         self.assertEqual(new_doc.Title(), "Document 1")
         self.assertEqual(new_doc.portal_type, "Document")
 
+    def test_import_content_from_central_directory(self):
+        from collective.exportimport import config
+        import tempfile
+
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        doc = api.content.create(
+            container=portal, type="Document", id="doc1", title="Document 1"
+        )
+        transaction.commit()
+
+        # Save the original, so we can restore it at the end of the test.
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+
+            # Now export the content to a file in this directory.
+            browser = self.open_page("@@export_content")
+            browser.getControl(name="portal_type").value = ["Document"]
+            browser.getControl("Save to file on server").click()
+            browser.getForm(action="@@export_content").submit(name="submit")
+
+            self.assertIn(
+                "Exported 1 items (Document) as Document.json", browser.contents
+            )
+            self.assertIn(config.CENTRAL_DIRECTORY, browser.contents)
+
+            # Move the exported file to the import directory.
+            export_path = os.path.join(config.CENTRAL_DIRECTORY, "Document.json")
+            self.assertTrue(os.path.isfile(export_path))
+
+            # Remove the added content.
+            api.content.delete(doc)
+            transaction.commit()
+            self.assertNotIn("doc1", portal.contentIds())
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_file")
+            server_file.value = ["Document.json"]
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 1 items", browser.contents)
+
+            # The document should be back.
+            self.assertIn("doc1", portal.contentIds())
+            new_doc = portal["doc1"]
+            self.assertEqual(new_doc.Title(), "Document 1")
+            self.assertEqual(new_doc.portal_type, "Document")
+
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
     def test_import_contenttree(self):
         # First create some content to export.
         app = self.layer["app"]


### PR DESCRIPTION
When set, this is used for storing an export file and getting an import file.
This is useful for sharing content between multiple Plone Sites on the same server.