### PR TITLE
Prevent creating content in a different Plone Site in the same database.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Prevent creating content in a different Plone Site in the same database (#52).
+  In general, cleanup parent paths when in development on localhost.
+  [maurits]
+
 - Read environment variable ``COLLECTIVE_EXPORTIMPORT_CENTRAL_DIRECTORY`` (#51).
   When set, this is used for storing an export file and getting an import file.
   This is useful for sharing content between multiple Plone Sites on the same server.


### PR DESCRIPTION
In general, cleanup parent paths when in development on localhost.
See explanation in `get_parent_as_container` method.

Also, in test_import_content_document test what happens when importing twice.
Biggest thing I wanted to check, because I had my doubts:
do we get the original UID on the first import, and a new UID on the second?
Answer: yes.