### PR TITLE
On Py 2.7, pin jsonschema to last compatible version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[bdist_wheel]
+# We check sys.version_info in setup.py, so we are not universal.
+universal = 0
+
 [check-manifest]
 ignore =
     *.cfg

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 from setuptools import find_packages
 from setuptools import setup
-import sys
 
 
 long_description = "\n\n".join(
@@ -17,7 +16,6 @@ long_description = "\n\n".join(
 install_requires = [
     "setuptools",
     "plone.api >= 1.8.4",
-    "plone.restapi < 8.0.0 ; python_version<'3'",
     "hurry.filesize",
     "ijson",
     "six",
@@ -25,6 +23,9 @@ install_requires = [
 
 if sys.version_info[0] < 3:
     install_requires.append("plone.restapi < 8.0.0")
+    # plone.restapi depends on plone.schema, which depends on jsonschema,
+    # which has a Py3-only release since September 2021.
+    install_requires.append("jsonschema < 4")
 else:
     install_requires.append("plone.restapi")
 


### PR DESCRIPTION
I noticed that on the main branch, the Plone [4.3 tests are broken](https://github.com/collective/collective.exportimport/runs/3766167980), trying to install `jsonschema`.

Version 4 of jsonschema was released yesterday, and it is Py3-only.
I don't know who pulls in this dependency.

jsonschema itself depends on six >= 1.11.0.
Since Plone 5.1 pins six to 1.10.0, we need to pin this as well.