### PR TITLE
Fixed ImportError when z3c.relationfield is missing.

### DIFF
--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -24,7 +24,6 @@ from plone.portlets.constants import (
     CONTENT_TYPE_CATEGORY,
     CONTEXT_CATEGORY,
 )
-from z3c.relationfield import RelationValue
 from zope.component import getUtilitiesFor
 from zope.component import queryMultiAdapter
 from zope.interface import providedBy
@@ -48,6 +47,13 @@ except pkg_resources.DistributionNotFound:
     HAS_DX = False
 else:
     HAS_DX = True
+
+try:
+    pkg_resources.get_distribution("z3c.relationfield")
+except pkg_resources.DistributionNotFound:
+    RelationValue = None
+else:
+    from z3c.relationfield import RelationValue
 
 
 logger = logging.getLogger(__name__)
@@ -545,7 +551,7 @@ def export_local_portlets(obj):
             values = {}
             for name in schema.names():
                 value = getattr(assignment, name, None)
-                if isinstance(value, RelationValue):
+                if RelationValue is not None and isinstance(value, RelationValue):
                     value = value.to_object.UID()
                 elif isinstance(value, RichTextValue):
                     value = {


### PR DESCRIPTION
I already fixed this half a year or so ago in export_content.py, but now a similar problem is there in export_other.py.
I tried creating an extra tox env for this, with Products.CMFPlone 4.3 instead of Plone,
but z3c.relationfield was pulled in anyway, probably via a test dependency.