### PR TITLE
Log exception when failing to export content

### DIFF
--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -296,7 +296,7 @@ class ExportContent(BrowserView):
 
                 yield item
             except Exception as e:
-                logger.info(u"Error exporting {}: {}".format(obj.absolute_url(), e))
+                logger.exception(u"Error exporting {}".format(obj.absolute_url()))
 
     def portal_types(self):
         """A list with info on all content types with existing items."""


### PR DESCRIPTION
Given the logging settings, errors were being swallowed and this was impossible to debug.