### PR TITLE
Ensure that links with spaces (arguably valid) do not get double-appended as a result of srcset processing.

### DIFF
--- a/src/collective/exportimport/fix_html.py
+++ b/src/collective/exportimport/fix_html.py
@@ -99,8 +99,8 @@ def fix_tag_attr(soup, tag, attr, old_portal_url, obj=None):
         orig = content_link.decode()  # to compare
 
         if attr == "srcset":
-            links = [x.split(maxsplit=1)[0] for x in origlink.split(",")]
-            addenda = [x.split(maxsplit=1)[1:] for x in origlink.split(",")]
+            links = [x.split(None, 1)[0] for x in origlink.split(",")]
+            addenda = [x.split(None, 1)[1:] for x in origlink.split(",")]
         else:
             links = [origlink]
             addenda = [[]]

--- a/src/collective/exportimport/fix_html.py
+++ b/src/collective/exportimport/fix_html.py
@@ -99,9 +99,11 @@ def fix_tag_attr(soup, tag, attr, old_portal_url, obj=None):
         orig = content_link.decode()  # to compare
 
         if attr == "srcset":
-            links = [x.split()[0].strip() for x in origlink.split(",")]
+            links = [x.split(maxsplit=1)[0] for x in origlink.split(",")]
+            addenda = [x.split(maxsplit=1)[1:] for x in origlink.split(",")]
         else:
             links = [origlink]
+            addenda = [[]]
         if not links:
             # Ignore tags with no usable content
             continue
@@ -212,8 +214,8 @@ def fix_tag_attr(soup, tag, attr, old_portal_url, obj=None):
             links[n] = new_href
 
         content_link[attr] = ",".join(
-            " ".join([links[n]] + x.split()[1:])
-            for n, x in enumerate(origlink.split(","))
+            " ".join([link] + addendum)
+            for link, addendum in zip(links, addenda)
         )
 
         if orig != content_link.decode():

--- a/src/collective/exportimport/tests/test_fix_html.py
+++ b/src/collective/exportimport/tests/test_fix_html.py
@@ -208,3 +208,24 @@ class TestFixHTML(unittest.TestCase):
             "Fixed HTML for 1 fields in content items. Fixed HTML for 0 portlets.",
             html,
         )
+
+    def test_fix_html_does_not_change_normal_links(self):
+        """Test that the content does not change in extraneous ways."""
+        self.create_demo_content()
+        old_text = '<a href="http://www.googlefight.com/cgi-bin/compare.pl?q1=Rudd-O&amp;q2=Andufo&amp;B1=Make a fight%21&amp;compare=1&amp;langue=us">Result for the fight between Rudd-O and Andufo</a>'
+        doc = api.content.create(
+            container=self.about,
+            type="Document",
+            id="doc1",
+            text=RichTextValue(old_text, "text/html", "text/x-html-safe"),
+        )
+        form = self.portal.restrictedTraverse("@@fix_html")
+        html = form()
+        self.request.form.update({
+            "form.submitted": True,
+            "form.commit": False,
+        })
+        html = form()
+        fixed_html = '<a href="http://www.googlefight.com/cgi-bin/compare.pl?q1=Rudd-O&amp;q2=Andufo&amp;B1=Make a fight%21&amp;compare=1&amp;langue=us">Result for the fight between Rudd-O and Andufo</a>'
+        self.assertEqual(fixed_html, doc.text.raw)
+        self.assertIn("Fixed HTML for 0 fields in content items. Fixed HTML for 0 portlets.", html)


### PR DESCRIPTION
This time we include a test to ensure we don't hit this condition.