### PR TITLE
Fixes TALES serializer in raw text instead of evaluated expression.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 
 - Export import of redirect tool data
   [gotcha, Michael Penninck]
+- Serialize Products.TALESField fields as raw instead of evaluated expression 
+  (useful to export PFG overrides)
+  [sauzher]
 
 
 1.4 (2022-01-07)

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -98,6 +98,10 @@
       factory=".serializer.ATImageFieldSerializer" />
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATImageFieldSerializerForBlobPaths" />
+  
+  <adapter zcml:condition="installed Products.Archetypes"
+      factory=".serializer.ATTalesFieldSerializer" />
+      
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATTextFieldSerializer" />
   <configure zcml:condition="installed Products.Archetypes">

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -99,7 +99,7 @@
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATImageFieldSerializerForBlobPaths" />
   
-  <adapter zcml:condition="installed Products.Archetypes"
+  <adapter zcml:condition="installed Products.TALESField"
       factory=".serializer.ATTalesFieldSerializer" />
       
   <adapter zcml:condition="installed Products.Archetypes"

--- a/src/collective/exportimport/interfaces.py
+++ b/src/collective/exportimport/interfaces.py
@@ -17,3 +17,7 @@ class IRawRichTextMarker(Interface):
 
 class IMigrationMarker(Interface):
     """A marker interface to override default serializers when data is used for migrations."""
+
+
+class ITalesField(Interface):
+    """a marker interface to export TalesField """

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -2,6 +2,7 @@
 from collective.exportimport.interfaces import IBase64BlobsMarker
 from collective.exportimport.interfaces import IMigrationMarker
 from collective.exportimport.interfaces import IPathBlobsMarker
+from collective.exportimport.interfaces import ITalesField
 from collective.exportimport.interfaces import IRawRichTextMarker
 from hurry.filesize import size
 from plone.app.textfield.interfaces import IRichText
@@ -15,6 +16,7 @@ from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getUtility
 from zope.interface import implementer
+from zope.interface import Interface
 
 import base64
 import logging
@@ -135,6 +137,22 @@ if HAS_AT:
     from Products.Archetypes.interfaces.field import IFileField
     from Products.Archetypes.interfaces.field import IImageField
     from Products.Archetypes.interfaces.field import ITextField
+
+    from zope.interface import classImplements
+    from Products.TALESField._field import TALESString
+    
+    # Products.TalesField does not implements any interface
+    # we mark the field class to let queryMultiAdapter intercept
+    # this in place of the default one that would returns 
+    # the evaluated expression instead of the raw expression itself
+    classImplements(TALESString, ITalesField)
+
+    @adapter(ITalesField, IBaseObject, Interface)
+    @implementer(IFieldSerializer)
+    class ATTalesFieldSerializer(ATDefaultFieldSerializer):
+        def __call__(self):
+            return json_compatible(self.field.getRaw(self.context))
+
 
     @adapter(IImageField, IBaseObject, IBase64BlobsMarker)
     @implementer(IFieldSerializer)
@@ -318,7 +336,7 @@ if HAS_AT and HAS_PAC:
     from plone.restapi.interfaces import ISerializeToJson
     from plone.restapi.serializer.atcontent import SerializeToJson
     from Products.ATContentTypes.interfaces.topic import IATTopic
-
+    
     @implementer(ISerializeToJson)
     @adapter(IATTopic, IMigrationMarker)
     class SerializeTopicToJson(SerializeToJson):


### PR DESCRIPTION
Exporting a PloneFormGen all the TALES override expressions are converted in their respective evaluated expressions because of restapi `DefaultFieldSerializer` that uses default accessor(). Then Deserializing the json yields to a conversion error: it expects strings but finds all kind of type of values returned by the tales.

With this PR, tales expression are kept in their raw string value into the Json so the defaultdeserializer can do the job.


