### PR TITLE
Use catalog and uuids to export/import default_page

### DIFF
--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -13,6 +13,7 @@ from plone.uuid.interfaces import IUUID
 from plone.app.uuid.utils import uuidToObject
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
@@ -464,9 +465,13 @@ class ExportDefaultPages(BrowserView):
         results = []
         catalog = api.portal.get_tool("portal_catalog")
         for brain in catalog.unrestrictedSearchResults(is_folderish=True, sort_on="path"):
-            uid = brain.UID
             try:
                 obj = brain.getObject()
+                if IPloneSiteRoot.providedBy(obj):
+                    # Plone 6
+                    continue
+                uid = brain.UID
+
                 # We use a simplified method to only get index_html
                 # and the property default_page on the object.
                 # We don't care about other cases

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -491,9 +491,16 @@ class ExportDefaultPages(BrowserView):
                 continue
 
         portal = api.portal.get()
-        portal_default_page = getattr(portal, 'default_page', [])
-        if portal_default_page:
-            results.append({"uuid": config.SITE_ROOT, "default_page": portal_default_page})
+        default_page = getattr(portal, 'default_page', [])
+        if default_page and default_page in portal:
+            default_page_obj = portal.get(default_page)
+            if default_page_obj:
+                default_page_uid = IUUID(default_page_obj, None)
+                results.append({
+                    "uuid": config.SITE_ROOT,
+                    "default_page": default_page,
+                    "default_page_uuid": default_page_uid,
+                })
         return results
 
 

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -311,7 +311,7 @@ class TestExport(unittest.TestCase):
         folder1 = api.content.create(
             container=portal, type="Folder", id="folder1", title="Folder 1"
         )
-        api.content.create(
+        doc1 = api.content.create(
             container=folder1, type="Document", id="doc1", title="Document 1"
         )
         folder1._setProperty("default_page", "doc1")
@@ -325,7 +325,7 @@ class TestExport(unittest.TestCase):
         data = json.loads(contents)
         self.assertListEqual(
             data,
-            [{"default_page": "doc1", "uuid": folder1.UID()}],
+            [{"default_page": "doc1", "uuid": folder1.UID(), 'default_page_uuid': doc1.UID()}],
         )
 
     def test_export_defaultpage_for_site(self):
@@ -333,7 +333,7 @@ class TestExport(unittest.TestCase):
         app = self.layer["app"]
         portal = self.layer["portal"]
         login(app, SITE_OWNER_NAME)
-        api.content.create(
+        doc1 = api.content.create(
             container=portal, type="Document", id="doc1", title="Document 1"
         )
         portal._setProperty("default_page", "doc1")
@@ -347,7 +347,7 @@ class TestExport(unittest.TestCase):
         data = json.loads(contents)
         self.assertListEqual(
             data,
-            [{"default_page": "doc1", "uuid": config.SITE_ROOT}],
+            [{"default_page": "doc1", "uuid": config.SITE_ROOT, "default_page_uuid": doc1.UID()}],
         )
 
     def test_export_ordering(self):


### PR DESCRIPTION
The old version did not account for default_pages that changed teir id during exportimport and failed to find the default page for translated items.