### PR TITLE
Use parent uuid to find the container to import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Export parent UID and use it to find the container to import.
+  [pbauer]
+
+- Move the various export-hooks into update_export_data for readability.
+  [pbauer]
 
 
 1.5 (2022-04-26)

--- a/src/collective/exportimport/tests/test_import.py
+++ b/src/collective/exportimport/tests/test_import.py
@@ -644,6 +644,8 @@ class TestImport(unittest.TestCase):
 
         data = json.loads(contents)
         self.assertEqual(len(data), 6)
+        # uuid of parents is exported
+        self.assertEqual(data[1]["parent"]["UID"], portal["about"].UID())
 
         # Remove the added content.
         self.remove_demo_content()


### PR DESCRIPTION
I don't know why I did not have this idea earlier. Using the parent UID makes it much easier to deal with cases where content moves around during migrations (e.g. when migrating to plone.app.multilingual).

Also this moves the various export-hooks into update_export_data for readability.