### PR TITLE
Add export and import for non-default registry settings

### DIFF
--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -91,6 +91,14 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      name="export_registry"
+      for="zope.interface.Interface"
+      class=".export_registry.ExportRegistry"
+      template="templates/export_registry.pt"
+      permission="cmf.ManagePortal"
+      />
+
   <!-- Serializers -->
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATFileFieldSerializer" />
@@ -230,6 +238,14 @@
       for="zope.interface.Interface"
       class=".import_other.ImportRedirects"
       template="templates/import_redirects.pt"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:page
+      name="import_registry"
+      for="zope.interface.Interface"
+      class=".import_registry.ImportRegistry"
+      template="templates/import_registry.pt"
       permission="cmf.ManagePortal"
       />
 

--- a/src/collective/exportimport/export_registry.py
+++ b/src/collective/exportimport/export_registry.py
@@ -29,7 +29,7 @@ class ExportRegistry(BaseExport):
         self.interfaces = self.request.form.get("interfaces", [])
         if not isinstance(self.interfaces, list):
             self.interfaces = [self.interfaces]
-        self.skip_defaults = self.request.form.get("skip_defaults", False)
+        self.skip_defaults = self.request.form.get("skip_defaults", True)
         self.all_interfacenames_with_prefix = self.get_all_interfacenames_with_prefix()
         if not self.request.form.get("form.submitted", False):
             return self.index()

--- a/src/collective/exportimport/export_registry.py
+++ b/src/collective/exportimport/export_registry.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport.export_other import BaseExport
+from logging import getLogger
+from plone.dexterity.interfaces import IDexterityContent
+from plone.registry.interfaces import IRegistry
+from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.serializer.converters import json_compatible
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.dottedname.resolve import resolve
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
+
+logger = getLogger(__name__)
+
+
+class ExportRegistry(BaseExport):
+
+    # This can hold interfaces, keys and prefixes
+    IGNORELIST = [
+        "plone.app.querystring.interfaces.IQueryField",
+        "plone.app.querystring.interfaces.IQueryOperation",
+        "Products.CMFPlone.interfaces.resources.IResourceRegistry",
+    ]
+
+    def __call__(self, download_to_server=False):
+        self.title = "Export registry settings"
+        self.download_to_server = download_to_server
+        self.interfaces = self.request.form.get("interfaces", [])
+        if not isinstance(self.interfaces, list):
+            self.interfaces = [self.interfaces]
+        self.skip_defaults = self.request.form.get("skip_defaults", False)
+        self.all_interfacenames_with_prefix = self.get_all_interfacenames_with_prefix()
+        if not self.request.form.get("form.submitted", False):
+            return self.index()
+
+        data = self.registry_config(interfaces=self.interfaces, skip_defaults=self.skip_defaults)
+        self.download(data)
+
+    def registry_config(self, interfaces=[], skip_defaults=True):
+        results = {}
+        registry = getUtility(IRegistry)
+        for path in interfaces:
+            try:
+                iface = resolve(path)
+            except:
+                logger.debug("{} not used in this site".format(path))
+                continue
+            items = {}
+            prefix = self.all_interfacenames_with_prefix[path] or path
+            proxy = registry.forInterface(iface, check=False, prefix=prefix)
+            for key, field in proxy.__schema__.namesAndDescriptions():
+                default = field.default
+                name = prefix + '.' + key
+
+                value = registry.get(name, None)
+                if value is None:
+                    # This means that the default value is used
+                    continue
+
+                if skip_defaults and value == default:
+                    continue
+
+                alsoProvides(proxy, IDexterityContent)
+                serializer = queryMultiAdapter((field, proxy, self.request), IFieldSerializer)
+                noLongerProvides(proxy, IDexterityContent)
+                if serializer:
+                    value = serializer()
+                else:
+                    value = json_compatible(value)
+                items[name] = value
+
+            if items:
+                results[path] = items
+        return results
+
+    def get_all_interfacenames_with_prefix(self):
+        results = []
+        res = {}
+        registry = getUtility(IRegistry)
+        for record in registry.records.values():
+            key = record.__name__
+            prefix = ".".join(key.split(".")[:-1])
+            interfacename = record.interfaceName
+
+            if record.interfaceName == record.__name__:
+                continue
+
+            if not interfacename or interfacename in self.IGNORELIST:
+                continue
+            if key in self.IGNORELIST or prefix in self.IGNORELIST:
+                continue
+
+            if interfacename == prefix:
+                prefix = None
+            results.append((interfacename, prefix))
+
+        for interfacename, prefix in sorted(results):
+            res[interfacename] = prefix
+        return res

--- a/src/collective/exportimport/import_registry.py
+++ b/src/collective/exportimport/import_registry.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport.interfaces import IMigrationMarker
+from logging import getLogger
+from plone import api
+from plone.dexterity.interfaces import IDexterityContent
+from plone.registry.interfaces import IRegistry
+from plone.restapi.interfaces import IFieldDeserializer
+from Products.Five import BrowserView
+from Products.Five import BrowserView
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
+from ZPublisher.HTTPRequest import FileUpload
+
+import json
+
+logger = getLogger(__name__)
+
+
+class ImportRegistry(BrowserView):
+    """Import registry settings"""
+
+    def __call__(self, jsonfile=None, return_json=False):
+        if jsonfile:
+            self.portal = api.portal.get()
+            status = "success"
+            try:
+                if isinstance(jsonfile, str):
+                    return_json = True
+                    data = json.loads(jsonfile)
+                elif isinstance(jsonfile, FileUpload):
+                    data = json.loads(jsonfile.read())
+                else:
+                    raise ("Data is neither text nor upload.")
+            except Exception as e:
+                status = "error"
+                logger.error(e)
+                api.portal.show_message(
+                    u"Failure while uploading: {}".format(e),
+                    request=self.request,
+                )
+            else:
+                results = self.import_registry(data)
+                msg = u"Imported {} registry records".format(len(results))
+                api.portal.show_message(msg, self.request)
+                for msg in results:
+                    api.portal.show_message(msg, self.request)
+            if return_json:
+                msg = {"state": status, "msg": msg}
+                return json.dumps(msg)
+
+        return self.index()
+
+    def import_registry(self, data):
+        alsoProvides(self.request, IMigrationMarker)
+        registry = getUtility(IRegistry)
+        records = registry.records
+        results = []
+        for interface, item in data.items():
+            for key in item:
+                try:
+                    proxy = records[key]
+                except KeyError:
+                    logger.info(u"Registry has no record for %s", key)
+                    continue
+                current_value = proxy.value
+                value = item[key]
+                if current_value == value:
+                    logger.debug(u"No changes to %s as %r", key, value)
+                    continue
+
+                try:
+                    proxy.field.validate(value)
+                except:
+                    alsoProvides(proxy, IDexterityContent)
+                    deserializer = queryMultiAdapter((proxy.field, proxy, self.request), IFieldDeserializer)
+                    if deserializer:
+                        try:
+                            value = deserializer(value)
+                        except Exception as e:
+                            logger.error(u"Could not import %s as %s", value, key, exc_info=True)
+                            pass
+                    noLongerProvides(proxy, IDexterityContent)
+
+                if current_value == value:
+                    logger.debug(u"No changes to %s as %r", key, value)
+                    continue
+
+                try:
+                    registry[key] = value
+                except Exception:
+                    logger.error(u"Could not import %s as %r", value, key, exc_info=True)
+                    continue
+                else:
+                    msg = u"Imported {} as {}".format(key, value)
+                    logger.info(msg)
+                    results.append(msg)
+        return results

--- a/src/collective/exportimport/templates/export_registry.pt
+++ b/src/collective/exportimport/templates/export_registry.pt
@@ -68,8 +68,7 @@
                     class="form-check-input"
                     name="skip_defaults:boolean"
                     id="skip_defaults"
-                    value="1"
-                    checked
+                    tal:attributes="checked python:'checked' if view.skip_defaults else None"
                     />
                 Skip default values
                 <span class="formHelp">

--- a/src/collective/exportimport/templates/export_registry.pt
+++ b/src/collective/exportimport/templates/export_registry.pt
@@ -1,0 +1,116 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone.z3cform"
+      metal:use-macro="context/main_template/macros/master">
+
+<div metal:fill-slot="main">
+    <tal:main-macro metal:define-macro="main">
+
+       <h1 class="documentFirstHeading" tal:content="python: view.title" i18n:translate="">
+           Export registry records
+       </h1>
+
+        <form id="export_registry" action="@@export_other" tal:attributes="action request/URL" method="post" enctype="multipart/form-data">
+
+            <div class="field mb-3">
+              <label for="interfaces">
+                <span i18n:translate="">Settings to export</span>
+              </label>
+              <div class="widget" id="interfaces">
+                <input type="checkbox" class="checkboxType" name="checkall" id="checkall"
+                       title="Toggle all" i18n:attributes="title label_toggle" />
+                <label for="checkall">Select all/none</label><br />
+                <script type="text/javascript">
+                   // Check or Uncheck All checkboxes
+                   $("#checkall").change(function(){
+                     var checked = $(this).is(':checked');
+                     if(checked){
+                       $("form#export_registry #interfaces input[type='checkbox']").each(function(){
+                         $(this).prop("checked",true);
+                       });
+                     }else{
+                       $("form#export_registry #interfaces input[type='checkbox']").each(function(){
+                         $(this).prop("checked",false);
+                       });
+                     }
+                   });
+
+                  // Changing state of CheckAll checkbox
+                  $("form#export_registry").on("click", "form#export_registry #interfaces input[name='interfaces']", function(){
+                    if($("form#export_registry #interfaces input[type='checkbox']").length == $("form#export_registry #ifacename input[type='checkbox']:checked").length) {
+                      $("#checkall").prop("checked", true);
+                    } else {
+                      $("#checkall").prop("checked", false);
+                    }
+
+                  });
+                </script>
+                <tal:types tal:repeat="ifacename python: view.all_interfacenames_with_prefix">
+                  <input type="checkbox"
+                         name="interfaces"
+                         class="checkboxType"
+                         tal:attributes="value python:ifacename; id python:ifacename;">
+                  <label tal:attributes="for python:ifacename">
+                    <span tal:replace="python:ifacename" />
+                    <span tal:condition="python:view.all_interfacenames_with_prefix[ifacename]" tal:replace="python: ' (prefix: ' + view.all_interfacenames_with_prefix[ifacename] + ')'" />
+                  </label>
+                         <br />
+                </tal:types>
+              </div>
+            </div>
+
+            <div class="field mb-3">
+              <label>
+                <input
+                    type="checkbox"
+                    class="form-check-input"
+                    name="skip_defaults:boolean"
+                    id="skip_defaults"
+                    value="1"
+                    checked
+                    />
+                Skip default values
+                <span class="formHelp">
+                  Ignore settings that were not changed
+                </span>
+              </label>
+            </div>
+
+            <div class="field mb-3">
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="download_to_server:int" value="0" id="download_local" checked="checked">
+                <label for="download_local" class="form-check-label"  i18n:translate="">
+                  Download to local machine
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="download_to_server:int" value="1" id="download_server">
+                <label for="download_server" class="form-check-label" i18n:translate="">
+                  Save to file on server
+                </label>
+              </div>
+            </div>
+
+            <div class="formControls" class="form-group">
+                <button class="btn btn-primary submit-widget button-field context"
+                        type="submit" name="form.submitted" value="Export" tal:content="python: view.title" i18n:translate="">Export
+                </button>
+            </div>
+        </form>
+
+        <div metal:use-macro="context/@@exportimport_links/links">
+          Links to all exports and imports
+        </div>
+
+        <div tal:define="help_text python: getattr(view, 'help_text', None)"
+             tal:condition="python: help_text">
+          <h3>Help</h3>
+          <div tal:replace="structure python: help_text"></div>
+        </div>
+
+    </tal:main-macro>
+</div>
+
+</html>

--- a/src/collective/exportimport/templates/import_registry.pt
+++ b/src/collective/exportimport/templates/import_registry.pt
@@ -1,0 +1,48 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone.z3cform"
+      metal:use-macro="context/main_template/macros/master">
+
+<div metal:fill-slot="main">
+    <tal:main-macro metal:define-macro="main">
+
+      <h1 class="documentFirstHeading">Import Registry Records</h1>
+
+      <p class="documentDescription">Here you can upload a json-file.</p>
+
+        <form action="@@import_registry" tal:attributes="action request/URL" method="post" enctype="multipart/form-data">
+            <div class="form-group">
+                <input type="file" name="jsonfile"/><br/>
+            </div>
+            <div class="formControls" class="form-group">
+                <button class="btn btn-primary submit-widget button-field context"
+                        type="submit" name="form.submitted" value="Import">Import
+                </button>
+            </div>
+        </form>
+
+        <div metal:use-macro="context/@@exportimport_links/links">
+          Links to all exports and imports
+        </div>
+
+        <div>
+          <h3>Help</h3>
+          <p>Here is a example for the expected format. This is the format created by collective.exportimport when used for export.</p>
+          <pre>
+{
+    "plone.app.discussion.interfaces.IDiscussionSettings": {
+        "globally_enabled": true
+    },
+    "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings": {
+        "allowed": false
+    }
+}
+            </pre>
+        </div>
+
+    </tal:main-macro>
+</div>
+
+</html>

--- a/src/collective/exportimport/templates/links.pt
+++ b/src/collective/exportimport/templates/links.pt
@@ -42,6 +42,10 @@
          <li><a class=""
             tal:attributes="href python: portal_url + '/@@export_redirects'">Export redirects
          </a></li>
+
+         <li><a class=""
+            tal:attributes="href python: portal_url + '/@@export_registry'">Export registry settings
+         </a></li>
       </ul>
 
       <h3>Imports</h3>
@@ -84,6 +88,10 @@
 
       <li><a class=""
          tal:attributes="href python: portal_url + '/@@import_redirects'">Import redirects
+      </a></li>
+
+      <li><a class=""
+         tal:attributes="href python: portal_url + '/@@import_registry'">Import registry settings
       </a></li>
 
       <li><a class=""


### PR DESCRIPTION
I'm not 100% sure this is a good idea since importing settings from oder to newer versions only makes sense when checking every single setting manually. Also a lot of settings in Plone 4 are still in portal_properties and not covered here. The default Plone upgrade takes care of migrating these into the registry these but with exportimport this obviously does not happen.

On the other hand the ability to only export settings that were changed from the default can certainly make migrating much easier.