### PR TITLE
be more specific in the zcml condition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.6 (unreleased)
 ----------------
 
+- Be more specific in the import_translation endpoint condition to install in a site with p.a.multilingual 1.x
+  [erral]
+
 - Export parent UID and use it to find the container to import.
   [pbauer]
 

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -98,10 +98,10 @@
       factory=".serializer.ATImageFieldSerializer" />
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATImageFieldSerializerForBlobPaths" />
-  
+
   <adapter zcml:condition="installed Products.TALESField"
       factory=".serializer.ATTalesFieldSerializer" />
-      
+
   <adapter zcml:condition="installed Products.Archetypes"
       factory=".serializer.ATTextFieldSerializer" />
   <configure zcml:condition="installed Products.Archetypes">
@@ -161,7 +161,7 @@
       />
 
   <browser:page
-      zcml:condition="installed plone.app.multilingual"
+      zcml:condition="installed plone.app.multilingual.interfaces.ITranslationManager"
       name="import_translations"
       for="zope.interface.Interface"
       class=".import_other.ImportTranslations"

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -161,7 +161,7 @@
       />
 
   <browser:page
-      zcml:condition="installed plone.app.multilingual.interfaces.ITranslationManager"
+      zcml:condition="installed plone.app.multilingual"
       name="import_translations"
       for="zope.interface.Interface"
       class=".import_other.ImportTranslations"

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -164,6 +164,11 @@ if HAS_PAM:  # noqa: C901
         except TypeError as e:
             logger.info(u"Item is not translatable: {}".format(e))
 
+else:
+    class ImportTranslations(BrowserView):
+        def __call__(self, jsonfile=None, return_json=False):
+            return "This view only works when using plone.app.multilingual >= 2.0.0"
+
 
 class ImportMembers(BrowserView):
     """Import plone groups and members"""


### PR DESCRIPTION
Fixes #144 

This way the endpoint is registered only when `ITranslationManager` exists in p.a.multilingual, what happens in versions >= 2.

This way this addon can be used in Plone 4.3.x sites with p.a.multilingual 1.2.x. In such cases we just want to export the content, so we should not bother about not being able to import the translations.