### PR TITLE
use Language=all when exporting translations for plone.app.multilingual 1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.6 (unreleased)
 ----------------
 
+- Use `Language=all` when querying TranslationGroup items
+  [erral]
+
 - Export parent UID and use it to find the container to import.
   [pbauer]
 

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -60,13 +60,13 @@ else:
     from z3c.relationfield import RelationValue
 
 try:
-    from plone.app.multilingual.interfaces import ITranslationManager
-
-    ITranslationManager
-
+    pam_version = pkg_resources.get_distribution("plone.app.multilingual")
+    if pam_version.version < "2.0.0":
+        IS_PAM_1 = True
+    else:
+        IS_PAM_1 = False
+except pkg_resources.DistributionNotFound:
     IS_PAM_1 = False
-except ImportError:
-    IS_PAM_1 = True
 
 
 logger = logging.getLogger(__name__)

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -59,6 +59,15 @@ except pkg_resources.DistributionNotFound:
 else:
     from z3c.relationfield import RelationValue
 
+try:
+    from plone.app.multilingual.interfaces import ITranslationManager
+
+    ITranslationManager
+
+    IS_PAM_1 = False
+except ImportError:
+    IS_PAM_1 = True
+
 
 logger = logging.getLogger(__name__)
 
@@ -356,7 +365,10 @@ class ExportTranslations(BaseExport):
             return results
 
         for uid in portal_catalog.uniqueValuesFor("TranslationGroup"):
-            brains = portal_catalog(TranslationGroup=uid, Language='all')
+            query = {"TranslationGroup": uid}
+            if IS_PAM_1:
+                query.update({"Language": "all"})
+            brains = portal_catalog(query)
 
             if len(brains) < 2:
                 # logger.info(u'Skipping...{} {}'.format(uid, brains))

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -356,7 +356,7 @@ class ExportTranslations(BaseExport):
             return results
 
         for uid in portal_catalog.uniqueValuesFor("TranslationGroup"):
-            brains = portal_catalog(TranslationGroup=uid)
+            brains = portal_catalog(TranslationGroup=uid, Language='all')
 
             if len(brains) < 2:
                 # logger.info(u'Skipping...{} {}'.format(uid, brains))


### PR DESCRIPTION
In our case with Plone 4.3 and p.a.multilingual 1.2.x, I needed to add this, otherwise no translations where exported.

But I don't know if it's just one edge case or is a generic one. 

It requires further testing in old p.a.multilingual versions.