### PR TITLE
fix plone site as parent in case of migrating from a site hosted behind a domain

### DIFF
--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -854,6 +854,8 @@ class ImportContent(BrowserView):
         # so we need to encode parent_path before using plone.api.content.get
         if isinstance(self.context.getPhysicalPath()[0], bytes):
             parent_path = parent_path.encode("utf8")
+        if parent_path == "":
+            parent_path = "/"
         try:
             parent = api.content.get(path=parent_path)
         except NotFound:


### PR DESCRIPTION
When migration from a plone site pointed to by a domain, the root path becomes empty, and therefore `api.content.get(path=parent_path)` returns None. The plone site is not found as the parent for items contained.

All items basically ends in the items_without_parent file (I'm using the example from https://github.com/starzel/contentimport - we don't want to create parent folders if the parent cannot be found - all should be there, if not it would be an error in the migration)

I need an opinion on this before we merge. Maybe it's not the right approach? But it seems simple enough.
This works, when migrating from http://old.mydomain.com/ (which points directly to a plone site), to another plone site on http://staging.mydomain.com/

In this case the id of an item in the json output is:

    "@id": "http://old.mydomain.com/administration", 

The parent for this item is:

    "parent": {
        "@id": "http://old.mydomain.com", 
        "@type": "Plone Site", 
        "UID": null, 
        "description": "", 
        "title": "Site"
    }, 

