### PR TITLE
Handle Volto not using 'Folder' when trying to create missing parents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,12 @@ Changelog
   [maurits]
 
 - Let fix_html view work on the current context.  [maurits]
+
 - Fix the way we get a blob path. (#180)
   [ale-rt]
 
+- Create documents as containers for items without parent when documents are folderish.
+  [JeffersonBledsoe]
 
 1.7 (2023-01-20)
 ----------------

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -897,26 +897,19 @@ class ImportContent(BrowserView):
             # Get rid of it.
             parent_path = parent_path[1:]
 
+        # Handle folderish Documents provided by plone.volto
+        fti = getUtility(IDexterityFTI, name="Document")
+        parent_type = "Document" if fti.klass.endswith("FolderishDocument") else "Folder"
         # create original structure for imported content
         for element in parent_path:
             if element not in folder:
-                # Handle Volto not using 'Folder' for it's type and having support for folderish pages
-                parent_type = (
-                    "Document"
-                    if getattr(aq_base(folder), "isPrincipiaFolderish", False)
-                    else "Folder"
-                )
                 folder = api.content.create(
                     container=folder,
                     type=parent_type,
                     id=element,
                     title=element,
                 )
-                logger.info(
-                    u"Created container {} to hold {}".format(
-                        folder.absolute_url(), item["@id"]
-                    )
-                )
+                logger.info(u"Created container %s to hold %s", folder.absolute_url(), item["@id"])
             else:
                 folder = folder[element]
 

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -900,9 +900,15 @@ class ImportContent(BrowserView):
         # create original structure for imported content
         for element in parent_path:
             if element not in folder:
+                # Handle Volto not using 'Folder' for it's type and having support for folderish pages
+                parent_type = (
+                    "Document"
+                    if getattr(aq_base(folder), "isPrincipiaFolderish", False)
+                    else "Folder"
+                )
                 folder = api.content.create(
                     container=folder,
-                    type="Folder",
+                    type=parent_type,
                     id=element,
                     title=element,
                 )


### PR DESCRIPTION
When trying to import content into Volto that does not have a parent, the following exception occurs:

```
plone.api.exc.InvalidParameterError: Cannot add a 'Folder' object to the container.
Allowed types are:
Document
Event
File
Image
Link
News Item
Disallowed subobject type: Folder
```

This PR checks whether the root is folderish (as it is with Volto) and uses the `Page` type instead.

## Future
It would be nice if this was more generic (i.e. the type the parent should be was stored in the export), but this would likely have a big impact on the JSON size