### PR TITLE
Fix the build on Plone 5.2/Python 3.6

### DIFF
--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -2,3 +2,6 @@
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
     base.cfg
+
+[versions:python36]
+charset-normalizer = 2.0.12


### PR DESCRIPTION
Was failing with:
```
Version and requirements information containing charset-normalizer:
  [versions] constraint on charset-normalizer: 2.1.1
  Requirement of requests: charset-normalizer~=2.0.0
While:
  Installing test.
```

See, e.g. https://github.com/collective/collective.exportimport/actions/runs/4086004109/jobs/7044735464