### PR TITLE
CI: pin setuptools lower than 67.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.0.1
+# setuptools 67 is too strict with versions
+setuptools<67


### PR DESCRIPTION
setuptools 67 is too strict.
See test failure here:
https://github.com/collective/collective.exportimport/actions/runs/4135262761/jobs/7147478436#step:9:55 Products.CMFPlone 5.2.11 depends on plone.app.contentmenu>=1.1.6dev-r22380 and this is an illegal requirement with setuptools 67. I will fix that for the next Plone version.