### PR TITLE
Import: run set_uuid method before we call custom hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.8 (unreleased)
 ----------------
 
+- Import: run set_uuid method before we call custom hooks, so the hooks have access to
+  the item UUID. Fix #185.
+  [fredvd]
+
 - Add Spanish translation.
   [macagua]
 

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -443,6 +443,13 @@ class ImportContent(BrowserView):
         uuid = self.set_uuid(item, new)
 
         if uuid != item.get("UID"):
+            # Happens only when we import content that doesn't have a UID
+            # for instance when importing from non Plone systems.
+            logger.info(
+                "Created new UID for item %s with type %s.",
+                item["@id"],
+                item["@type"]
+            )
             item["UID"] = uuid
 
         self.global_obj_hook(new, item)

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -440,13 +440,13 @@ class ImportContent(BrowserView):
         self.import_blob_paths(new, item)
         self.import_constrains(new, item)
 
-        self.global_obj_hook(new, item)
-        self.custom_obj_hook(new, item)
-
         uuid = self.set_uuid(item, new)
 
         if uuid != item.get("UID"):
             item["UID"] = uuid
+
+        self.global_obj_hook(new, item)
+        self.custom_obj_hook(new, item)
 
         # Try to set the original review_state
         self.import_review_state(new, item)


### PR DESCRIPTION
This allows the hooks to have access to the item UUID. Fix #185.

One item of concern: I have now also moved the check if the 'set' uid matches the uid on the import item dict.   

>             if uuid != item.get("UID"):
>                item["UID"] = uuid


In theory this causes the custom dict hooks to no longer have access to that uuid or override this action.  Should the condition be moved after the custom dict hooks calls? 

The original commit for this condiation had this comment: " Support importing content without a UUID (e.g. for importing from an external source"

