### PR TITLE
Do not import groups that a group belongs to as members of the new group.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 - Migrate root of portlets that used a path in plone4 to using a uid (navigation, search, events, collection).
   [pbauer]
 
+- Fix critical bug when importing groups: Do not import groups that a groups belongs to as members of the new group.
+  This could have caused groups to have more privileges than they should.
+  [pbauer]
+
 
 1.8 (2023-04-20)
 ----------------

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -219,7 +219,6 @@ class ImportMembers(BrowserView):
                     title=item["title"],
                     description=item["description"],
                     roles=item["roles"],
-                    groups=item["groups"],
                 )
                 # add all principals
                 for principal in item.get("principals", []):


### PR DESCRIPTION
This was a critical bug when importing groups. The json for exported groups has the data `group["groups"]`. That is a list of groups to which the group belongs to. This data need not be used during import and is rather for information and debugging. `group["principals"]` is a list of all members of the group (be they groups or users).