### PR TITLE
add savepoint

### DIFF
--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -301,6 +301,7 @@ class ImportContent(BrowserView):
 
             if not index % 100:
                 logger.info("Imported {} items...".format(index))
+                transaction.savepoint()
 
             new_id = unquote(item["@id"]).split("/")[-1]
             if new_id != item["id"]:


### PR DESCRIPTION
context: Import items transaction failed quietly when importing a lot of files/images from blobstorage. This was solved by adding a transaction savepoint for every imported 100 items