### PR TITLE
208 better reporting of failed exported objects

### DIFF
--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -142,6 +142,7 @@ class ExportContent(BrowserView):
             ("2", _(u"as blob paths")),
         )
         self.include_revisions = include_revisions
+        self.write_errors = write_errors or self.request.form.get("write_errors")
 
         self.update()
 
@@ -175,8 +176,6 @@ class ExportContent(BrowserView):
             else:
                 filename = self.path.split("/")[-1]
             filename = "{}.json".format(filename)
-
-        self.write_errors = write_errors or self.request.form.get("write_errors")
 
         self.errors = []
         content_generator = self.export_content()

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -303,12 +303,12 @@ class ExportContent(BrowserView):
             try:
                 obj = brain.getObject()
             except Exception:
-                msg = f"Error getting brain {brain.getPath()}"
+                msg = u"Error getting brain {}".format(brain.getPath())
                 self.errors.append({'path':None, 'message': msg})
                 logger.exception(msg, exc_info=True)
                 continue
             if obj is None:
-                msg = f'brain.getObject() is None {brain.getPath()}'
+                msg = u"brain.getObject() is None {}}".format(brain.getPath())
                 logger.error(msg)
                 self.errors.append({'path':None, 'message': msg})
                 continue
@@ -328,7 +328,7 @@ class ExportContent(BrowserView):
 
                 yield item
             except Exception:
-                msg = f"Error exporting {obj.absolute_url()}"
+                msg = u"Error exporting {}}".format(obj.absolute_url())
                 self.errors.append({'path':obj.absolute_url(), 'message':msg})
                 logger.exception(msg, exc_info=True)
 

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -201,6 +201,7 @@ class ExportContent(BrowserView):
                     json.dump(datum, f, sort_keys=True, indent=4)
                 if number:
                     if self.errors and self.write_errors:
+                        f.write(",")
                         errors = {"unexported_paths": self.errors}
                         json.dump(errors, f, indent=4)
                     f.write("]")
@@ -228,6 +229,7 @@ class ExportContent(BrowserView):
                     json.dump(datum, f, sort_keys=True, indent=4)
                 if number:
                     if  self.errors and self.write_errors:
+                        f.write(",")
                         errors = {"unexported_paths": self.errors}
                         json.dump(errors, f, indent=4)
                     f.write("]")

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -308,7 +308,7 @@ class ExportContent(BrowserView):
                 logger.exception(msg, exc_info=True)
                 continue
             if obj is None:
-                msg = u"brain.getObject() is None {}}".format(brain.getPath())
+                msg = u"brain.getObject() is None {}".format(brain.getPath())
                 logger.error(msg)
                 self.errors.append({'path':None, 'message': msg})
                 continue
@@ -328,7 +328,7 @@ class ExportContent(BrowserView):
 
                 yield item
             except Exception:
-                msg = u"Error exporting {}}".format(obj.absolute_url())
+                msg = u"Error exporting {}".format(obj.absolute_url())
                 self.errors.append({'path':obj.absolute_url(), 'message':msg})
                 logger.exception(msg, exc_info=True)
 

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -302,11 +302,13 @@ class ExportContent(BrowserView):
                 obj = brain.getObject()
             except Exception:
                 msg = f"Error getting brain {brain.getPath()}"
-                self.errors.append((None, msg))
+                self.errors.append({'path':None, 'message': msg})
                 logger.exception(msg, exc_info=True)
                 continue
             if obj is None:
-                logger.error(u"brain.getObject() is None %s", brain.getPath())
+                msg = f'brain.getObject() is None {brain.getPath()}'
+                logger.error(msg)
+                self.errors.append({'path':None, 'message': msg})
                 continue
             obj = self.global_obj_hook(obj)
             if not obj:
@@ -325,7 +327,7 @@ class ExportContent(BrowserView):
                 yield item
             except Exception:
                 msg = f"Error exporting {obj.absolute_url()}"
-                self.errors.append((obj.absolute_url(), msg))
+                self.errors.append({'path':obj.absolute_url(), 'message':msg})
                 logger.exception(msg, exc_info=True)
 
     def portal_types(self):

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -112,6 +112,7 @@ class ExportContent(BrowserView):
         download_to_server=False,
         migration=True,
         include_revisions=False,
+        write_errors=False
     ):
         self.portal_type = portal_type or []
         if isinstance(self.portal_type, str):
@@ -175,6 +176,9 @@ class ExportContent(BrowserView):
                 filename = self.path.split("/")[-1]
             filename = "{}.json".format(filename)
 
+        self.write_errors = write_errors or self.request.form.get("write_errors")
+
+        self.errors = []
         content_generator = self.export_content()
 
         number = 0
@@ -197,9 +201,12 @@ class ExportContent(BrowserView):
                         f.write(",")
                     json.dump(datum, f, sort_keys=True, indent=4)
                 if number:
+                    if self.errors and self.write_errors:
+                        errors = {"unexported_paths": self.errors}
+                        json.dump(errors, f, indent=4)
                     f.write("]")
-            msg = _(u"Exported {} items ({}) as {} to {}").format(
-                number, ", ".join(self.portal_type), filename, filepath
+            msg = _(u"Exported {} items ({}) as {} to {} with {} errors").format(
+                number, ", ".join(self.portal_type), filename, filepath, len(self.errors)
             )
             logger.info(msg)
             api.portal.show_message(msg, self.request)
@@ -221,8 +228,11 @@ class ExportContent(BrowserView):
                         f.write(",")
                     json.dump(datum, f, sort_keys=True, indent=4)
                 if number:
+                    if  self.errors and self.write_errors:
+                        errors = {"unexported_paths": self.errors}
+                        json.dump(errors, f, indent=4)
                     f.write("]")
-                msg = _(u"Exported {} {}").format(number, self.portal_type)
+                msg = _(u"Exported {} {} with {} errors").format(number, self.portal_type, len(self.errors))
                 logger.info(msg)
                 api.portal.show_message(msg, self.request)
                 response = self.request.response
@@ -292,7 +302,9 @@ class ExportContent(BrowserView):
             try:
                 obj = brain.getObject()
             except Exception:
-                logger.exception(u"Error getting brain %s", brain.getPath(), exc_info=True)
+                msg = f"Error getting brain {brain.getPath()}"
+                self.errors.append((None, msg))
+                logger.exception(msg, exc_info=True)
                 continue
             if obj is None:
                 logger.error(u"brain.getObject() is None %s", brain.getPath())
@@ -313,7 +325,9 @@ class ExportContent(BrowserView):
 
                 yield item
             except Exception:
-                logger.exception(u"Error exporting %s", obj.absolute_url(), exc_info=True)
+                msg = f"Error exporting {obj.absolute_url()}"
+                self.errors.append((obj.absolute_url(), msg))
+                logger.exception(msg, exc_info=True)
 
     def portal_types(self):
         """A list with info on all content types with existing items."""

--- a/src/collective/exportimport/templates/export_content.pt
+++ b/src/collective/exportimport/templates/export_content.pt
@@ -134,6 +134,22 @@
             </div>
 
             <div class="field mb-3">
+              <label>
+                <input
+                    type="checkbox"
+                    class="form-check-input"
+                    name="write_errors:boolean"
+                    id="write_errors"
+                    tal:attributes="checked python: 'checked' if view.write_errors else None"
+                    />
+                <span i18n:translate="">Write out Errors to file.</span>
+                <span class="formHelp" i18n:translate="">
+                  Checking this box puts a list of object paths at the end of the export file that failed to export.
+                </span>
+              </label>
+            </div>
+
+            <div class="field mb-3">
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="download_to_server:int" value="0" id="download_local" checked="checked">
                 <label for="download_local" class="form-check-label" i18n:translate="">


### PR DESCRIPTION
This adds a new form field on `@@export_content` "write_errors" which turns on a list of unexported paths at the end of a json export.

When 'write_errors' is set to a true value, the export appends the list like so:

```
[{
    "@id": "http://localhost:8081/RFA/english/item1",
    "@type": "news_item",
    "UID": "34b9faa0dbe648b6826174abc4ff85c1",
    ... <snip>
},
{
    "@id": "http://localhost:8081/RFA/english/item2",
    "@type": "news_item",
    "UID": "34b9faa0dbe648b6826174abc4ff85c2",
    ... <snip>
},{
    "@id": "http://localhost:8081/RFA/english/item3",
    "@type": "news_item",
    "UID": "34b9faa0dbe648b6826174abc4ff85c3",
    ... <snip>
},{
    "unexported_paths": [
        {
            "path": "http://localhost:8081/RFA/english/news/story-slideshow-05232023120021.html",
            "message": "Error exporting http://localhost:8081/RFA/english/news/story-slideshow-05232023120021.html"
        }
    ]
}]

```

Additionally, ~some log messages were converted to 'f' strings to "leave it better than you found it" and~ error logs now show number of errors or 'skipped objects' during export:

    2023-06-08 13:55:06,216 INFO    [collective.exportimport.export_content:237][waitress-0] Exported 50 ['Image', 'Kaltura Video', 'press release', 'raw html', 'section', 'Slideshow', 'story', 'subsite', 'testipublication', 'chair'] with 1 errors


