### PR TITLE
fix: don't re-use `mapping` variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Don't re-use `mapping` variable when migrating portlet data.
+  [witsch]
 
 
 1.9 (2023-05-18)

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -749,7 +749,7 @@ def register_portlets(obj, item):
             portlet_interface = getUtility(IPortletTypeInterface, name=portlet_type)
             for property_name, value in assignment_data.items():
                 # For core portlets a path changed to uuid between Plone 4 and 5
-                migration_mapping = [
+                migration_mappings = [
                     {
                         "portlet_type": "portlets.Navigation",
                         "old": "root",
@@ -771,13 +771,13 @@ def register_portlets(obj, item):
                         "new": "uid",
                     },
                 ]
-                for mapping in migration_mapping:
+                for migration_mapping in migration_mappings:
                     if (
-                        property_name == mapping["old"]
+                        property_name == migration_mapping["old"]
                         and value
-                        and portlet_type == mapping["portlet_type"]
+                        and portlet_type == migration_mapping["portlet_type"]
                     ):
-                        property_name = mapping["new"]
+                        property_name = migration_mapping["new"]
                         target = api.content.get(path=value)
                         if target:
                             value = target.UID()


### PR DESCRIPTION
Otherwise only one portlet will be successfully imported for each location and column as all remaining ones are placed into the wrong `mapping`.

This fixes 6b4bdc50.