### PR TITLE
Better support for portal import.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog
 - Don't re-use `mapping` variable when migrating portlet data.
   [witsch]
 
+- Better support for portal import which avoids parsing JSON twice.
+  [gotcha]
 
 1.9 (2023-05-18)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ install_requires = [
 if sys.version_info[0] < 3:
     install_requires.append("beautifulsoup4 < 4.10")
     install_requires.append("plone.restapi < 8.0.0")
+    # There is a py2-imcompatibility in plone.rest 3.0.1
+    install_requires.append("plone.rest < 3.0.1")
     # plone.restapi depends on plone.schema, which depends on jsonschema,
     # which has a Py3-only release since September 2021.
     install_requires.append("jsonschema < 4")

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -428,9 +428,15 @@ class ImportContent(BrowserView):
 
         # import using plone.restapi deserializers
         deserializer = getMultiAdapter((new, self.request), IDeserializeFromJson)
-        self.request["BODY"] = json.dumps(item)
         try:
-            new = deserializer(validate_all=False)
+            try:
+                new = deserializer(validate_all=False, data=item)
+            except TypeError as error:
+                if 'unexpected keyword argument' in str(error):
+                    self.request["BODY"] = json.dumps(item)
+                    new = deserializer(validate_all=False)
+                else:
+                    raise error
         except Exception:
             logger.warning("Cannot deserialize %s %s", item["@type"], item["@id"], exc_info=True)
             raise


### PR DESCRIPTION
Avoid parsing JSON twice and dumping once for each content object.

The only deserializer that does not support data as keyword argument is the portal deserializer.

For all other content items, dumping to JSON to setup the request before loading from JSON in the `json_body` function is really overkill as the item has already been parsed when loaded from file.