### PR TITLE
migrate portlets on site root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog
 
 - Better support for portal import which avoids parsing JSON twice.
   [gotcha]
+- Migrate portlets on site root.
+  [ThibautBorn]
 
 1.9 (2023-05-18)
 ----------------

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -639,12 +639,16 @@ class ExportPortlets(BaseExport):
         self.results = []
         portal = api.portal.get()
         portal.ZopeFindAndApply(self.context, search_sub=True, apply_func=self.get_portlets)
+        self.get_root_portlets()
         return self.results
 
-    def get_portlets(self,obj, path):
+    def get_portlets(self, obj, path):
         uid = IUUID(obj, None)
         if not uid:
             return
+        self._get_portlets(obj, uid)
+
+    def _get_portlets(self, obj, uid):
         portlets = export_local_portlets(obj)
         blacklist = export_portlets_blacklist(obj)
         portlets = self.local_portlets_hook(portlets)
@@ -658,6 +662,11 @@ class ExportPortlets(BaseExport):
             obj_results["@id"] = obj.absolute_url()
             obj_results["uuid"] = uid
             self.results.append(obj_results)
+        return
+    
+    def get_root_portlets(self):
+        site = api.portal.get()
+        self._get_portlets(site, PORTAL_PLACEHOLDER)
         return
 
     def local_portlets_hook(self, portlets):

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -700,7 +700,11 @@ class ImportPortlets(BrowserView):
         for item in data:
             obj = api.content.get(UID=item["uuid"])
             if not obj:
-                continue
+                if item["uuid"] == PORTAL_PLACEHOLDER:
+                    obj = api.portal.get()
+                else:
+                    logger.info("Could not find object to set portlet on UUID: {}".format(item["uuid"]))
+                    continue
             registered_portlets = register_portlets(obj, item)
             results += registered_portlets
         return results


### PR DESCRIPTION
context: migration only checked on uid, which left out the portal root. (and the portlets on the root weren't migrated) 