### PR TITLE
Fix writing error-file with separate JSON file export.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- When exporting into separate JSON files write also the error in a separate errors.json file.
+  This fixes an error at the end of the export and no errors being written.
+  [thet]
 
 
 1.10 (2023-10-11)

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -208,7 +208,8 @@ class ExportContent(BrowserView):
             if number:
                 if self.errors and self.write_errors:
                     errors = {"unexported_paths": self.errors}
-                    json.dump(errors, f, indent=4)
+                    with open(os.path.join(directory, "errors.json"), "w") as f:
+                        json.dump(errors, f, indent=4)
             msg = _(u"Exported {} items ({}) to {} with {} errors").format(
                 number, ", ".join(self.portal_type), directory, len(self.errors)
             )


### PR DESCRIPTION
When exporting into separate JSON files write also the error in a separate errors.json file. This fixes an error at the end of the export and no errors being written.