### PR TITLE
Hierarchical export/import to server, single json per item. Moving and deletion allowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ report.html
 .tox/
 reports/
 # excludes
+.DS_Store
+*.bak

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,16 @@ Changelog
   This fixes an error at the end of the export and no errors being written.
   [thet]
 
+- Adds hierarchical content export/import. A folder structure will be created and a json file per item.
+  This will allow to keep track of changes for each item. Also allow to move o delete content.
+  [rber474]
+
+- Some fixes for spanish translations
+  [rber474]
+
+- Modifies import_content and export_content templates to include boostrap classes and change checkboxes to switches.
+  [rber474]
+
 
 1.10 (2023-10-11)
 -----------------

--- a/src/collective/exportimport/config.py
+++ b/src/collective/exportimport/config.py
@@ -16,3 +16,5 @@ SITE_ROOT = 'plone_site_root'
 
 # Discussion Item has its own export / import views, don't show it in the exportable content type list
 SKIPPED_CONTENTTYPE_IDS = ['Discussion Item']
+
+TREE_DIRECTORY = "exported_tree"

--- a/src/collective/exportimport/filesystem_exporter.py
+++ b/src/collective/exportimport/filesystem_exporter.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+from App.config import getConfiguration
+from collective.exportimport import config
+from plone import api
+from six.moves.urllib.parse import unquote, urlparse
+
+import json
+import logging
+import os
+
+
+class FileSystemExporter(object):
+    """Base FS Exporter"""
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self):
+        self._create_base_dirs()
+
+    def _create_base_dirs(self):
+        """Creates base content directory and subdir deleted_items"""
+        # Will generate a directory tree with one json file per item
+        portal_id = api.portal.get().getId()
+        directory = config.CENTRAL_DIRECTORY
+        if not directory:
+            cfg = getConfiguration()
+            directory = cfg.clienthome
+
+        self.root = os.path.join(
+            directory, "exported_tree/%s/content" % portal_id
+        )
+        self._make_dir(self.root)
+
+        remove_dir = os.path.join(
+            directory, "exported_tree/%s/removed_items" % portal_id
+        )
+        self._make_dir(remove_dir)
+
+        return self.root
+
+    def _make_dir(self, path):
+        """Make directory"""
+        if not os.path.exists(path):
+            os.makedirs(path)
+            self.logger.info("Created path %s", path)
+
+    def create_dir(self, dirname):
+        """Creates a directory if does not exist
+
+        Args:
+            dirname (str): dirname to be created
+        """
+        dirpath = os.path.join(self.root, dirname)
+        self._make_dir(dirpath)
+
+    def get_parents(self, parent):
+        """Extracts parents of item
+
+        Args:
+            parent (dict): Parent info dict
+
+        Returns:
+            (str): relative path
+        """
+
+        if not parent:
+            return ""
+
+        parent_url = unquote(parent["@id"])
+        parent_url_parsed = urlparse(parent_url)
+
+        # Get the path part, split it, remove the always empty first element.
+        parent_path = parent_url_parsed.path.split("/")[1:]
+        if (
+            len(parent_url_parsed.netloc.split(":")) > 1
+            or parent_url_parsed.netloc == "nohost"
+        ):
+            # For example localhost:8080, or nohost when running tests.
+            # First element will then be a Plone Site id.
+            # Get rid of it.
+            parent_path = parent_path[1:]
+
+        return "/".join(parent_path)
+
+
+class FileSystemContentExporter(FileSystemExporter):
+    """Deserializes JSON items into a FS tree"""
+
+    def save(self, number, item):
+        """Saves a json file to filesystem tree
+        Target directory is related as original parent position in site.
+        """
+
+        parent_path = self.get_parents(item.get("parent"))
+
+        if item.get("is_folderish", False):
+            item_path = os.path.join(parent_path, item.get("id"))
+            self.create_dir(item_path)
+        else:
+            self.create_dir(parent_path)
+
+        # filename = "%s_%s_%s.json" % (number, item.get("@type"), item.get("UID"))
+        filename = "%s_%s.json" % (number, item.get("id"))
+        filepath = os.path.join(self.root, parent_path, filename)
+        with open(filepath, "w") as f:
+            json.dump(item, f, sort_keys=True, indent=4)

--- a/src/collective/exportimport/filesystem_importer.py
+++ b/src/collective/exportimport/filesystem_importer.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport import _
+from glob import iglob
+from plone import api
+from six.moves.urllib.parse import unquote, urlparse
+
+import json
+import logging
+import os
+import six
+
+
+if six.PY2:
+    from pathlib2 import Path
+else:
+    from pathlib import Path
+
+
+class FileSystemImporter(object):
+    """Base FS Importer"""
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, context, server_tree_file):
+        self.path = server_tree_file
+        self.context = context
+
+    def get_parents(self, parent):
+        """Extracts parents of item
+
+        Args:
+            parent (dict): Parent info dict
+
+        Returns:
+            (str): relative path
+        """
+
+        if not parent:
+            return ""
+
+        parent_url = unquote(parent["@id"])
+        parent_url_parsed = urlparse(parent_url)
+
+        # Get the path part, split it, remove the always empty first element.
+        parent_path = parent_url_parsed.path.split("/")[1:]
+        if (
+            len(parent_url_parsed.netloc.split(":")) > 1
+            or parent_url_parsed.netloc == "nohost"
+        ):
+            # For example localhost:8080, or nohost when running tests.
+            # First element will then be a Plone Site id.
+            # Get rid of it.
+            parent_path = parent_path[1:]
+
+        return "/".join(parent_path)
+
+
+class FileSystemContentImporter(FileSystemImporter):
+    """Deserializes JSON items into a FS tree"""
+
+    def list_files(self):
+        """Loads all json files from filesystem tree"""
+        files = iglob(os.path.join(self.path, "**/*.json"), recursive=True)
+        return files
+
+    def get_hierarchical_files(self):
+        """Gets all files and folders"""
+        root = Path(self.path)
+        portal = api.portal.get()
+        assert root.is_dir()
+
+        json_files = root.glob("**/*.json")
+        for json_file in json_files:
+            self.logger.debug("Importing %s", json_file)
+            item = json.loads(json_file.read_text())
+            json_parent = item.get("parent", {})
+
+            # Find the real parent nodes as they could be moved
+            # among directories
+            prefix = os.path.commonprefix([str(json_file.parent), self.path])
+
+            # relative path will be the diference between base export path
+            # and the position of the json file
+            relative_path = os.path.relpath(str(json_file.parent), prefix)
+            parent_path = "%s/%s" % (
+                "/".join(self.context.getPhysicalPath()),
+                relative_path)
+            parents = self.get_parents(json_parent)
+
+            if json_file.parent == Path(os.path.join(self.path, parents)):
+                yield item
+            else:
+                parent_obj = api.content.get(path=parent_path)
+                if not parent_obj:
+                    # if parent_path is "." or parent_obj doesn't yet exist
+                    parent_obj = portal
+
+                # Modify parent data into json to be yield
+                # local files won't be modified
+                if parent_obj:
+                    self.delete_old_if_moved(item.get("UID"))
+                    item["@id"] = item.get("@id")
+                    json_parent.update(
+                        {"@id": parent_obj.absolute_url(), "UID": parent_obj.UID()}
+                    )
+                    item["parent"] = json_parent
+                yield item
+
+    def delete_old_if_moved(self, UID):
+        """Checks if json file was moved by
+        getting object by UID. If exists, removes object"""
+        check_if_moved = api.content.get(UID=UID)
+        if check_if_moved:
+            # delete all object
+            api.content.delete(obj=check_if_moved, check_linkintegrity=False)
+            self.logger.info("Removed old object %s", check_if_moved.UID())
+
+    def process_deleted(self):
+        """Will process all elements in removed_items dir"""
+        root = Path(self.path).parent
+        removed_items_dir = root / "removed_items"
+        json_files = removed_items_dir.glob("**/*.json")
+        deleted_items = []
+        for json_file in json_files:
+            self.logger.debug("Deleting %s", json_file)
+            item = json.loads(json_file.read_text())
+            uid = item.get("UID")
+            obj = api.content.get(UID=uid)
+            if obj:
+                api.content.delete(obj=obj, check_linkintegrity=False)
+                self.logger.info("Deleted object %s", item.get("UID"))
+                deleted_items.append(uid)
+
+        return self.context.translate(
+            _(
+                "deleted_items_msg",
+                default=u"Deleted ${items} items.",
+                mapping={u"items": len(deleted_items)}
+            )
+        )

--- a/src/collective/exportimport/locales/collective.exportimport.pot
+++ b/src/collective/exportimport/locales/collective.exportimport.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-17 02:40+0000\n"
+"POT-Creation-Date: 2023-10-13 22:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,435 +17,495 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.exportimport\n"
 
-#: collective/exportimport/import_content.py:961
+#: ../templates/import_content.pt:99
+msgid "# Elements"
+msgstr ""
+
+#: ../import_content.py:1069
 msgid "<p>Creation- and modification-dates are changed during import.This resets them to the original dates of the imported content.</p>"
 msgstr ""
 
-#: collective/exportimport/import_content.py:992
+#: ../import_content.py:1100
 msgid "<p>This fixes invalid collection-criteria that were imported from Plone 4 or 5.</p>"
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:32
+#: ../templates/import_redirects.pt:32
 msgid "Beware that this import would work only if you keep the same Plone site id and location in the site !"
 msgstr ""
 
-#: collective/exportimport/import_other.py:517
+#: ../import_other.py:521
 msgid "Changed {} default pages"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:30
+#: ../templates/export_content.pt:154
+msgid "Checking this box puts a list of object paths at the end of the export file that failed to export."
+msgstr ""
+
+#: ../templates/import_content.pt:33
 msgid "Choose one"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:19
+#: ../templates/export_content.pt:19
 msgid "Content Types to export"
 msgstr ""
 
-#: collective/exportimport/import_other.py:687
+#: ../import_other.py:690
 msgid "Created {} portlets"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:71
+#: ../templates/export_content.pt:77
 msgid "Depth"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:56
+#: ../templates/import_content.pt:46
+msgid "Directory on server to import:"
+msgstr ""
+
+#: ../templates/import_content.pt:97
 msgid "Do a commit after each number of items"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:139
-#: collective/exportimport/templates/export_other.pt:19
+#: ../templates/export_content.pt:162
+#: ../templates/export_other.pt:19
 msgid "Download to local machine"
 msgstr ""
 
-#: collective/exportimport/import_content.py:179
+#: ../import_content.py:213
 msgid "Exception during upload: {}"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:155
-#: collective/exportimport/templates/export_other.pt:32
+#: ../templates/export_content.pt:190
+#: ../templates/export_other.pt:32
 msgid "Export"
 msgstr ""
 
-#: collective/exportimport/export_other.py:585
-#: collective/exportimport/templates/links.pt:38
+#: ../export_other.py:587
+#: ../templates/links.pt:38
 msgid "Export comments"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:11
-#: collective/exportimport/templates/links.pt:10
+#: ../templates/export_content.pt:11
+#: ../templates/links.pt:10
 msgid "Export content"
 msgstr ""
 
-#: collective/exportimport/export_other.py:506
-#: collective/exportimport/templates/links.pt:30
+#: ../export_other.py:508
+#: ../templates/links.pt:30
 msgid "Export default pages"
 msgstr ""
 
-#: collective/exportimport/export_other.py:413
-#: collective/exportimport/templates/links.pt:26
+#: ../export_other.py:415
+#: ../templates/links.pt:26
 msgid "Export local roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:22
+#: ../templates/links.pt:22
 msgid "Export members"
 msgstr ""
 
-#: collective/exportimport/export_other.py:233
+#: ../export_other.py:235
 msgid "Export members, groups and roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:34
+#: ../templates/links.pt:34
 msgid "Export object positions in parent"
 msgstr ""
 
-#: collective/exportimport/export_other.py:470
+#: ../export_other.py:472
 msgid "Export ordering"
 msgstr ""
 
-#: collective/exportimport/export_other.py:624
-#: collective/exportimport/templates/links.pt:42
+#: ../export_other.py:628
+#: ../templates/links.pt:42
 msgid "Export portlets"
 msgstr ""
 
-#: collective/exportimport/export_other.py:759
-#: collective/exportimport/templates/links.pt:46
+#: ../export_other.py:779
+#: ../templates/links.pt:46
 msgid "Export redirects"
 msgstr ""
 
-#: collective/exportimport/export_other.py:125
-#: collective/exportimport/templates/links.pt:14
+#: ../export_other.py:127
+#: ../templates/links.pt:14
 msgid "Export relations"
 msgstr ""
 
-#: collective/exportimport/export_other.py:331
-#: collective/exportimport/templates/links.pt:18
+#: ../export_other.py:333
+#: ../templates/links.pt:18
 msgid "Export translations"
 msgstr ""
 
-#: collective/exportimport/export_other.py:101
+#: ../export_other.py:103
 msgid "Exported to {}"
 msgstr ""
 
-#: collective/exportimport/export_content.py:198
-msgid "Exported {} items ({}) as {} to {}"
+#: ../export_content.py:271
+msgid "Exported {} items ({}) as {} to {} with {} errors"
 msgstr ""
 
-#: collective/exportimport/export_content.py:222
-msgid "Exported {} {}"
+#: ../export_content.py:213
+msgid "Exported {} items ({}) to {} with {} errors"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:8
+#: ../export_content.py:299
+msgid "Exported {} {} with {} errors"
+msgstr ""
+
+#: ../templates/links.pt:8
 msgid "Exports"
 msgstr ""
 
-#: collective/exportimport/import_other.py:91
+#: ../import_other.py:93
 msgid "Failure while uploading: {}"
 msgstr ""
 
-#: collective/exportimport/import_content.py:160
+#: ../import_content.py:194
 msgid "File '{}' not found on server."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:27
+#: ../templates/import_content.pt:30
 msgid "File on server to import:"
 msgstr ""
 
-#: collective/exportimport/import_content.py:1006
+#: ../import_content.py:1114
 msgid "Finished fixing collection queries."
 msgstr ""
 
-#: collective/exportimport/import_content.py:969
+#: ../import_content.py:1077
 msgid "Finished resetting creation and modification dates."
 msgstr ""
 
-#: collective/exportimport/import_content.py:991
-#: collective/exportimport/templates/links.pt:97
+#: ../import_content.py:1099
+#: ../templates/links.pt:97
 msgid "Fix collection queries"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:43
-#: collective/exportimport/templates/links.pt:101
+#: ../fix_html.py:43
+#: ../templates/links.pt:101
 msgid "Fix links to content and images in richtext"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:51
+#: ../fix_html.py:51
 msgid "Fixed HTML for {} fields in content items"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:55
+#: ../fix_html.py:55
 msgid "Fixed HTML for {} portlets"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:38
+#: ../templates/export_content.pt:180
+msgid "Generate a file for each item (as filesytem tree)"
+msgstr ""
+
+#: ../templates/import_content.pt:79
 msgid "Handle existing content"
 msgstr ""
 
-#: collective/exportimport/templates/export_other.pt:44
-#: collective/exportimport/templates/import_defaultpages.pt:31
-#: collective/exportimport/templates/import_discussion.pt:31
+#: ../templates/export_other.pt:44
+#: ../templates/import_defaultpages.pt:31
+#: ../templates/import_discussion.pt:31
 msgid "Help"
 msgstr ""
 
-#: collective/exportimport/templates/import_defaultpages.pt:32
-#: collective/exportimport/templates/import_discussion.pt:32
-#: collective/exportimport/templates/import_localroles.pt:32
+#: ../templates/import_defaultpages.pt:32
+#: ../templates/import_discussion.pt:32
+#: ../templates/import_localroles.pt:32
 msgid "Here is a example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:34
+#: ../templates/import_redirects.pt:34
 msgid "Here is an example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:13
-#: collective/exportimport/templates/import_defaultpages.pt:13
-#: collective/exportimport/templates/import_discussion.pt:13
+#: ../templates/import_content.pt:15
+#: ../templates/import_defaultpages.pt:13
+#: ../templates/import_discussion.pt:13
 msgid "Here you can upload a json-file."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:39
+#: ../templates/import_content.pt:90
 msgid "How should content be handled that exists with the same id/path?"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:88
+#: ../templates/export_content.pt:105
 msgid "How should data from image- and file-fields be included?"
 msgstr ""
 
-#: collective/exportimport/import_content.py:127
+#: ../import_content.py:161
 msgid "Ignore: Create with a new id"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:92
-#: collective/exportimport/templates/import_defaultpages.pt:20
-#: collective/exportimport/templates/import_discussion.pt:20
+#: ../templates/import_content.pt:134
+#: ../templates/import_defaultpages.pt:20
+#: ../templates/import_discussion.pt:20
 msgid "Import"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:11
+#: ../templates/import_content.pt:11
 msgid "Import Content"
 msgstr ""
 
-#: collective/exportimport/templates/import_defaultpages.pt:11
+#: ../templates/import_defaultpages.pt:11
 msgid "Import Default Pages"
 msgstr ""
 
-#: collective/exportimport/templates/import_discussion.pt:11
+#: ../templates/import_discussion.pt:11
 msgid "Import Discussion"
 msgstr ""
 
-#: collective/exportimport/templates/import_localroles.pt:11
+#: ../templates/import_localroles.pt:11
 msgid "Import Localroles"
 msgstr ""
 
-#: collective/exportimport/templates/import_members.pt:11
+#: ../templates/import_members.pt:11
 msgid "Import Members, Groups and their Roles"
 msgstr ""
 
-#: collective/exportimport/templates/import_ordering.pt:11
+#: ../templates/import_ordering.pt:11
 msgid "Import Object Positions in Parent"
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:11
+#: ../templates/import_redirects.pt:11
 msgid "Import Redirects"
 msgstr ""
 
-#: collective/exportimport/templates/import_relations.pt:11
+#: ../templates/import_relations.pt:11
 msgid "Import Relations"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:71
+#: ../templates/import_content.pt:113
 msgid "Import all items into the current folder"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:83
+#: ../templates/import_content.pt:125
 msgid "Import all old revisions"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:81
+#: ../templates/links.pt:81
 msgid "Import comments"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:53
+#: ../templates/links.pt:53
 msgid "Import content"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:73
+#: ../templates/links.pt:73
 msgid "Import default pages"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:69
+#: ../templates/links.pt:69
 msgid "Import local roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:65
+#: ../templates/links.pt:65
 msgid "Import members"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:77
+#: ../templates/links.pt:77
 msgid "Import object positions in parent"
 msgstr ""
 
-#: collective/exportimport/templates/import_portlets.pt:11
-#: collective/exportimport/templates/links.pt:85
+#: ../templates/import_portlets.pt:11
+#: ../templates/links.pt:85
 msgid "Import portlets"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:89
+#: ../templates/links.pt:89
 msgid "Import redirects"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:57
+#: ../templates/links.pt:57
 msgid "Import relations"
 msgstr ""
 
-#: collective/exportimport/templates/import_translations.pt:11
-#: collective/exportimport/templates/links.pt:61
+#: ../templates/import_translations.pt:11
+#: ../templates/links.pt:61
 msgid "Import translations"
 msgstr ""
 
-#: collective/exportimport/import_other.py:590
+#: ../import_other.py:594
 msgid "Imported {} comments"
 msgstr ""
 
-#: collective/exportimport/import_other.py:201
+#: ../import_other.py:203
 msgid "Imported {} groups and {} members"
 msgstr ""
 
-#: collective/exportimport/import_other.py:392
+#: ../import_other.py:393
 msgid "Imported {} localroles"
 msgstr ""
 
-#: collective/exportimport/import_other.py:464
+#: ../import_other.py:468
 msgid "Imported {} orders in {} seconds"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:51
+#: ../templates/links.pt:51
 msgid "Imports"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:87
+#: ../templates/export_content.pt:94
 msgid "Include blobs"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:129
+#: ../templates/export_content.pt:136
 msgid "Include revisions."
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:113
+#: ../templates/export_content.pt:120
 msgid "Modify exported data for migrations."
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:33
+#: ../templates/import_redirects.pt:33
 msgid "More code is needed if you have another use case."
 msgstr ""
 
-#: collective/exportimport/export_other.py:84
+#: ../export_other.py:86
 msgid "No data to export for {}"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:25
-msgid "No files found."
+#: ../templates/import_content.pt:44
+msgid "No directories to import from found."
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:63
+#: ../templates/import_content.pt:28
+msgid "No json-files found."
+msgstr ""
+
+#: ../templates/import_content.pt:77
+msgid "Options"
+msgstr ""
+
+#: ../templates/export_content.pt:69
 msgid "Path"
 msgstr ""
 
-#: collective/exportimport/import_other.py:822
+#: ../import_other.py:873
 msgid "Redirects imported"
 msgstr ""
 
-#: collective/exportimport/import_content.py:125
+#: ../import_content.py:159
 msgid "Replace: Delete item and create new"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:93
+#: ../templates/links.pt:93
 msgid "Reset created and modified dates"
 msgstr ""
 
-#: collective/exportimport/import_content.py:960
+#: ../import_content.py:1068
 msgid "Reset creation and modification date"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:145
-#: collective/exportimport/templates/export_other.pt:25
+#: ../templates/export_content.pt:174
+msgid "Save each item as a separate file on the server"
+msgstr ""
+
+#: ../templates/export_content.pt:168
+#: ../templates/export_other.pt:25
 msgid "Save to file on server"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:24
+#: ../templates/export_content.pt:25
 msgid "Select all/none"
 msgstr ""
 
-#: collective/exportimport/export_content.py:150
+#: ../export_content.py:154
 msgid "Select at least one type to export"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:13
+#: ../templates/export_content.pt:13
 msgid "Select which content to export as a json-file."
 msgstr ""
 
-#: collective/exportimport/import_content.py:124
+#: ../import_content.py:158
 msgid "Skip: Don't import at all"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:130
+#: ../templates/export_content.pt:138
 msgid "This exports the content-history (versioning) of each exported item. Warning: This can significantly slow down the export!"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:84
+#: ../templates/import_content.pt:127
 msgid "This will import the content-history (versioning) for each item that has revisions. Warning: This can significantly slow down the import!"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:72
+#: ../templates/export_content.pt:88
 msgid "Unlimited: this item and all children, 0: this object only, 1: only direct children of this object, 2-x: children of this object up to the specified level"
 msgstr ""
 
-#: collective/exportimport/import_content.py:126
+#: ../import_content.py:160
 msgid "Update: Reuse and only overwrite imported data"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:114
+#: ../templates/export_content.pt:122
 msgid "Use this if you want to import the data in a newer version of Plone or migrate from Archetypes to Dexterity. Read the documentation to learn which changes are made by this option."
 msgstr ""
 
-#: collective/exportimport/import_other.py:288
+#: ../templates/export_content.pt:152
+msgid "Write out Errors to file."
+msgstr ""
+
+#: ../templates/import_content.pt:21
+msgid "You can also select a json-file or a directory holding json-files on the server in the following locations:"
+msgstr ""
+
+#: ../import_other.py:289
 msgid "You need either Plone 6 or collective.relationhelpers to import relations"
 msgstr ""
 
-#: collective/exportimport/export_content.py:139
+#: ../export_content.py:142
 msgid "as base-64 encoded strings"
 msgstr ""
 
-#: collective/exportimport/export_content.py:140
+#: ../export_content.py:143
 msgid "as blob paths"
 msgstr ""
 
-#: collective/exportimport/export_content.py:138
+#: ../export_content.py:141
 msgid "as download urls"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:155
+#. Default: "Deleted ${items} items."
+#: ../filesystem_importer.py:135
+msgid "deleted_items_msg"
+msgstr ""
+
+#: ../templates/export_content.pt:190
 msgid "export"
 msgstr ""
 
-#: collective/exportimport/import_content.py:143
+#. Default: "Exported ${number} items (${types}) as tree to ${target} with ${errors} errors"
+#: ../export_content.py:233
+msgid "hierarchycal_export_success"
+msgstr ""
+
+#: ../import_content.py:177
 msgid "json file was uploaded, so the selected server file was ignored."
 msgstr ""
 
 #. Default: "Toggle all"
-#: collective/exportimport/templates/export_content.pt:22
+#: ../templates/export_content.pt:23
 msgid "label_toggle"
 msgstr ""
 
-#: collective/exportimport/import_content.py:996
+#: ../import_content.py:1104
 msgid "plone.app.querystring.upgrades.fix_select_all_existing_collections is not available"
 msgstr ""
 
-#. Default: "Or you can choose a file that is already uploaded on the server in one of these paths:"
-#: collective/exportimport/templates/import_content.pt:21
+#. Default: "Import from a json-file"
+#: ../templates/import_content.pt:27
 msgid "server_paths_list"
 msgstr ""
 
-#: collective/exportimport/export_content.py:123
+#. Default: "Or you can choose from a tree export in the server in one of these paths:"
+#: ../templates/import_content.pt:59
+msgid "server_paths_list_hierarchical"
+msgstr ""
+
+#. Default: "Import from a directory that holds individual json-files per item:"
+#: ../templates/import_content.pt:43
+msgid "server_paths_list_per_json_file"
+msgstr ""
+
+#: ../export_content.py:126
 msgid "unlimited"
 msgstr ""

--- a/src/collective/exportimport/locales/en/LC_MESSAGES/collective.exportimport.po
+++ b/src/collective/exportimport/locales/en/LC_MESSAGES/collective.exportimport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-17 02:40+0000\n"
+"POT-Creation-Date: 2023-10-13 22:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,435 +14,495 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/exportimport/import_content.py:961
+#: ../templates/import_content.pt:99
+msgid "# Elements"
+msgstr ""
+
+#: ../import_content.py:1069
 msgid "<p>Creation- and modification-dates are changed during import.This resets them to the original dates of the imported content.</p>"
 msgstr ""
 
-#: collective/exportimport/import_content.py:992
+#: ../import_content.py:1100
 msgid "<p>This fixes invalid collection-criteria that were imported from Plone 4 or 5.</p>"
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:32
+#: ../templates/import_redirects.pt:32
 msgid "Beware that this import would work only if you keep the same Plone site id and location in the site !"
 msgstr ""
 
-#: collective/exportimport/import_other.py:517
+#: ../import_other.py:521
 msgid "Changed {} default pages"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:30
+#: ../templates/export_content.pt:154
+msgid "Checking this box puts a list of object paths at the end of the export file that failed to export."
+msgstr ""
+
+#: ../templates/import_content.pt:33
 msgid "Choose one"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:19
+#: ../templates/export_content.pt:19
 msgid "Content Types to export"
 msgstr ""
 
-#: collective/exportimport/import_other.py:687
+#: ../import_other.py:690
 msgid "Created {} portlets"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:71
+#: ../templates/export_content.pt:77
 msgid "Depth"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:56
+#: ../templates/import_content.pt:46
+msgid "Directory on server to import:"
+msgstr ""
+
+#: ../templates/import_content.pt:97
 msgid "Do a commit after each number of items"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:139
-#: collective/exportimport/templates/export_other.pt:19
+#: ../templates/export_content.pt:162
+#: ../templates/export_other.pt:19
 msgid "Download to local machine"
 msgstr ""
 
-#: collective/exportimport/import_content.py:179
+#: ../import_content.py:213
 msgid "Exception during upload: {}"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:155
-#: collective/exportimport/templates/export_other.pt:32
+#: ../templates/export_content.pt:190
+#: ../templates/export_other.pt:32
 msgid "Export"
 msgstr ""
 
-#: collective/exportimport/export_other.py:585
-#: collective/exportimport/templates/links.pt:38
+#: ../export_other.py:587
+#: ../templates/links.pt:38
 msgid "Export comments"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:11
-#: collective/exportimport/templates/links.pt:10
+#: ../templates/export_content.pt:11
+#: ../templates/links.pt:10
 msgid "Export content"
 msgstr ""
 
-#: collective/exportimport/export_other.py:506
-#: collective/exportimport/templates/links.pt:30
+#: ../export_other.py:508
+#: ../templates/links.pt:30
 msgid "Export default pages"
 msgstr ""
 
-#: collective/exportimport/export_other.py:413
-#: collective/exportimport/templates/links.pt:26
+#: ../export_other.py:415
+#: ../templates/links.pt:26
 msgid "Export local roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:22
+#: ../templates/links.pt:22
 msgid "Export members"
 msgstr ""
 
-#: collective/exportimport/export_other.py:233
+#: ../export_other.py:235
 msgid "Export members, groups and roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:34
+#: ../templates/links.pt:34
 msgid "Export object positions in parent"
 msgstr ""
 
-#: collective/exportimport/export_other.py:470
+#: ../export_other.py:472
 msgid "Export ordering"
 msgstr ""
 
-#: collective/exportimport/export_other.py:624
-#: collective/exportimport/templates/links.pt:42
+#: ../export_other.py:628
+#: ../templates/links.pt:42
 msgid "Export portlets"
 msgstr ""
 
-#: collective/exportimport/export_other.py:759
-#: collective/exportimport/templates/links.pt:46
+#: ../export_other.py:779
+#: ../templates/links.pt:46
 msgid "Export redirects"
 msgstr ""
 
-#: collective/exportimport/export_other.py:125
-#: collective/exportimport/templates/links.pt:14
+#: ../export_other.py:127
+#: ../templates/links.pt:14
 msgid "Export relations"
 msgstr ""
 
-#: collective/exportimport/export_other.py:331
-#: collective/exportimport/templates/links.pt:18
+#: ../export_other.py:333
+#: ../templates/links.pt:18
 msgid "Export translations"
 msgstr ""
 
-#: collective/exportimport/export_other.py:101
+#: ../export_other.py:103
 msgid "Exported to {}"
 msgstr ""
 
-#: collective/exportimport/export_content.py:198
-msgid "Exported {} items ({}) as {} to {}"
+#: ../export_content.py:271
+msgid "Exported {} items ({}) as {} to {} with {} errors"
 msgstr ""
 
-#: collective/exportimport/export_content.py:222
-msgid "Exported {} {}"
+#: ../export_content.py:213
+msgid "Exported {} items ({}) to {} with {} errors"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:8
+#: ../export_content.py:299
+msgid "Exported {} {} with {} errors"
+msgstr ""
+
+#: ../templates/links.pt:8
 msgid "Exports"
 msgstr ""
 
-#: collective/exportimport/import_other.py:91
+#: ../import_other.py:93
 msgid "Failure while uploading: {}"
 msgstr ""
 
-#: collective/exportimport/import_content.py:160
+#: ../import_content.py:194
 msgid "File '{}' not found on server."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:27
+#: ../templates/import_content.pt:30
 msgid "File on server to import:"
 msgstr ""
 
-#: collective/exportimport/import_content.py:1006
+#: ../import_content.py:1114
 msgid "Finished fixing collection queries."
 msgstr ""
 
-#: collective/exportimport/import_content.py:969
+#: ../import_content.py:1077
 msgid "Finished resetting creation and modification dates."
 msgstr ""
 
-#: collective/exportimport/import_content.py:991
-#: collective/exportimport/templates/links.pt:97
+#: ../import_content.py:1099
+#: ../templates/links.pt:97
 msgid "Fix collection queries"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:43
-#: collective/exportimport/templates/links.pt:101
+#: ../fix_html.py:43
+#: ../templates/links.pt:101
 msgid "Fix links to content and images in richtext"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:51
+#: ../fix_html.py:51
 msgid "Fixed HTML for {} fields in content items"
 msgstr ""
 
-#: collective/exportimport/fix_html.py:55
+#: ../fix_html.py:55
 msgid "Fixed HTML for {} portlets"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:38
+#: ../templates/export_content.pt:180
+msgid "Generate a file for each item (as filesytem tree)"
+msgstr ""
+
+#: ../templates/import_content.pt:79
 msgid "Handle existing content"
 msgstr ""
 
-#: collective/exportimport/templates/export_other.pt:44
-#: collective/exportimport/templates/import_defaultpages.pt:31
-#: collective/exportimport/templates/import_discussion.pt:31
+#: ../templates/export_other.pt:44
+#: ../templates/import_defaultpages.pt:31
+#: ../templates/import_discussion.pt:31
 msgid "Help"
 msgstr ""
 
-#: collective/exportimport/templates/import_defaultpages.pt:32
-#: collective/exportimport/templates/import_discussion.pt:32
-#: collective/exportimport/templates/import_localroles.pt:32
+#: ../templates/import_defaultpages.pt:32
+#: ../templates/import_discussion.pt:32
+#: ../templates/import_localroles.pt:32
 msgid "Here is a example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:34
+#: ../templates/import_redirects.pt:34
 msgid "Here is an example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:13
-#: collective/exportimport/templates/import_defaultpages.pt:13
-#: collective/exportimport/templates/import_discussion.pt:13
+#: ../templates/import_content.pt:15
+#: ../templates/import_defaultpages.pt:13
+#: ../templates/import_discussion.pt:13
 msgid "Here you can upload a json-file."
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:39
+#: ../templates/import_content.pt:90
 msgid "How should content be handled that exists with the same id/path?"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:88
+#: ../templates/export_content.pt:105
 msgid "How should data from image- and file-fields be included?"
 msgstr ""
 
-#: collective/exportimport/import_content.py:127
+#: ../import_content.py:161
 msgid "Ignore: Create with a new id"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:92
-#: collective/exportimport/templates/import_defaultpages.pt:20
-#: collective/exportimport/templates/import_discussion.pt:20
+#: ../templates/import_content.pt:134
+#: ../templates/import_defaultpages.pt:20
+#: ../templates/import_discussion.pt:20
 msgid "Import"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:11
+#: ../templates/import_content.pt:11
 msgid "Import Content"
 msgstr ""
 
-#: collective/exportimport/templates/import_defaultpages.pt:11
+#: ../templates/import_defaultpages.pt:11
 msgid "Import Default Pages"
 msgstr ""
 
-#: collective/exportimport/templates/import_discussion.pt:11
+#: ../templates/import_discussion.pt:11
 msgid "Import Discussion"
 msgstr ""
 
-#: collective/exportimport/templates/import_localroles.pt:11
+#: ../templates/import_localroles.pt:11
 msgid "Import Localroles"
 msgstr ""
 
-#: collective/exportimport/templates/import_members.pt:11
+#: ../templates/import_members.pt:11
 msgid "Import Members, Groups and their Roles"
 msgstr ""
 
-#: collective/exportimport/templates/import_ordering.pt:11
+#: ../templates/import_ordering.pt:11
 msgid "Import Object Positions in Parent"
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:11
+#: ../templates/import_redirects.pt:11
 msgid "Import Redirects"
 msgstr ""
 
-#: collective/exportimport/templates/import_relations.pt:11
+#: ../templates/import_relations.pt:11
 msgid "Import Relations"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:71
+#: ../templates/import_content.pt:113
 msgid "Import all items into the current folder"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:83
+#: ../templates/import_content.pt:125
 msgid "Import all old revisions"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:81
+#: ../templates/links.pt:81
 msgid "Import comments"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:53
+#: ../templates/links.pt:53
 msgid "Import content"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:73
+#: ../templates/links.pt:73
 msgid "Import default pages"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:69
+#: ../templates/links.pt:69
 msgid "Import local roles"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:65
+#: ../templates/links.pt:65
 msgid "Import members"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:77
+#: ../templates/links.pt:77
 msgid "Import object positions in parent"
 msgstr ""
 
-#: collective/exportimport/templates/import_portlets.pt:11
-#: collective/exportimport/templates/links.pt:85
+#: ../templates/import_portlets.pt:11
+#: ../templates/links.pt:85
 msgid "Import portlets"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:89
+#: ../templates/links.pt:89
 msgid "Import redirects"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:57
+#: ../templates/links.pt:57
 msgid "Import relations"
 msgstr ""
 
-#: collective/exportimport/templates/import_translations.pt:11
-#: collective/exportimport/templates/links.pt:61
+#: ../templates/import_translations.pt:11
+#: ../templates/links.pt:61
 msgid "Import translations"
 msgstr ""
 
-#: collective/exportimport/import_other.py:590
+#: ../import_other.py:594
 msgid "Imported {} comments"
 msgstr ""
 
-#: collective/exportimport/import_other.py:201
+#: ../import_other.py:203
 msgid "Imported {} groups and {} members"
 msgstr ""
 
-#: collective/exportimport/import_other.py:392
+#: ../import_other.py:393
 msgid "Imported {} localroles"
 msgstr ""
 
-#: collective/exportimport/import_other.py:464
+#: ../import_other.py:468
 msgid "Imported {} orders in {} seconds"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:51
+#: ../templates/links.pt:51
 msgid "Imports"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:87
+#: ../templates/export_content.pt:94
 msgid "Include blobs"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:129
+#: ../templates/export_content.pt:136
 msgid "Include revisions."
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:113
+#: ../templates/export_content.pt:120
 msgid "Modify exported data for migrations."
 msgstr ""
 
-#: collective/exportimport/templates/import_redirects.pt:33
+#: ../templates/import_redirects.pt:33
 msgid "More code is needed if you have another use case."
 msgstr ""
 
-#: collective/exportimport/export_other.py:84
+#: ../export_other.py:86
 msgid "No data to export for {}"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:25
-msgid "No files found."
+#: ../templates/import_content.pt:44
+msgid "No directories to import from found."
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:63
+#: ../templates/import_content.pt:28
+msgid "No json-files found."
+msgstr ""
+
+#: ../templates/import_content.pt:77
+msgid "Options"
+msgstr ""
+
+#: ../templates/export_content.pt:69
 msgid "Path"
 msgstr ""
 
-#: collective/exportimport/import_other.py:822
+#: ../import_other.py:873
 msgid "Redirects imported"
 msgstr ""
 
-#: collective/exportimport/import_content.py:125
+#: ../import_content.py:159
 msgid "Replace: Delete item and create new"
 msgstr ""
 
-#: collective/exportimport/templates/links.pt:93
+#: ../templates/links.pt:93
 msgid "Reset created and modified dates"
 msgstr ""
 
-#: collective/exportimport/import_content.py:960
+#: ../import_content.py:1068
 msgid "Reset creation and modification date"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:145
-#: collective/exportimport/templates/export_other.pt:25
+#: ../templates/export_content.pt:174
+msgid "Save each item as a separate file on the server"
+msgstr ""
+
+#: ../templates/export_content.pt:168
+#: ../templates/export_other.pt:25
 msgid "Save to file on server"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:24
+#: ../templates/export_content.pt:25
 msgid "Select all/none"
 msgstr ""
 
-#: collective/exportimport/export_content.py:150
+#: ../export_content.py:154
 msgid "Select at least one type to export"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:13
+#: ../templates/export_content.pt:13
 msgid "Select which content to export as a json-file."
 msgstr ""
 
-#: collective/exportimport/import_content.py:124
+#: ../import_content.py:158
 msgid "Skip: Don't import at all"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:130
+#: ../templates/export_content.pt:138
 msgid "This exports the content-history (versioning) of each exported item. Warning: This can significantly slow down the export!"
 msgstr ""
 
-#: collective/exportimport/templates/import_content.pt:84
+#: ../templates/import_content.pt:127
 msgid "This will import the content-history (versioning) for each item that has revisions. Warning: This can significantly slow down the import!"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:72
+#: ../templates/export_content.pt:88
 msgid "Unlimited: this item and all children, 0: this object only, 1: only direct children of this object, 2-x: children of this object up to the specified level"
 msgstr ""
 
-#: collective/exportimport/import_content.py:126
+#: ../import_content.py:160
 msgid "Update: Reuse and only overwrite imported data"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:114
+#: ../templates/export_content.pt:122
 msgid "Use this if you want to import the data in a newer version of Plone or migrate from Archetypes to Dexterity. Read the documentation to learn which changes are made by this option."
 msgstr ""
 
-#: collective/exportimport/import_other.py:288
+#: ../templates/export_content.pt:152
+msgid "Write out Errors to file."
+msgstr ""
+
+#: ../templates/import_content.pt:21
+msgid "You can also select a json-file or a directory holding json-files on the server in the following locations:"
+msgstr ""
+
+#: ../import_other.py:289
 msgid "You need either Plone 6 or collective.relationhelpers to import relations"
 msgstr ""
 
-#: collective/exportimport/export_content.py:139
+#: ../export_content.py:142
 msgid "as base-64 encoded strings"
 msgstr ""
 
-#: collective/exportimport/export_content.py:140
+#: ../export_content.py:143
 msgid "as blob paths"
 msgstr ""
 
-#: collective/exportimport/export_content.py:138
+#: ../export_content.py:141
 msgid "as download urls"
 msgstr ""
 
-#: collective/exportimport/templates/export_content.pt:155
+#. Default: "Deleted ${items} items."
+#: ../filesystem_importer.py:135
+msgid "deleted_items_msg"
+msgstr ""
+
+#: ../templates/export_content.pt:190
 msgid "export"
 msgstr ""
 
-#: collective/exportimport/import_content.py:143
+#. Default: "Exported ${number} items (${types}) as tree to ${target} with ${errors} errors"
+#: ../export_content.py:233
+msgid "hierarchycal_export_success"
+msgstr ""
+
+#: ../import_content.py:177
 msgid "json file was uploaded, so the selected server file was ignored."
 msgstr ""
 
 #. Default: "Toggle all"
-#: collective/exportimport/templates/export_content.pt:22
+#: ../templates/export_content.pt:23
 msgid "label_toggle"
 msgstr ""
 
-#: collective/exportimport/import_content.py:996
+#: ../import_content.py:1104
 msgid "plone.app.querystring.upgrades.fix_select_all_existing_collections is not available"
 msgstr ""
 
-#. Default: "Or you can choose a file that is already uploaded on the server in one of these paths:"
-#: collective/exportimport/templates/import_content.pt:21
+#. Default: "Import from a json-file"
+#: ../templates/import_content.pt:27
 msgid "server_paths_list"
 msgstr ""
 
-#: collective/exportimport/export_content.py:123
+#. Default: "Or you can choose from a tree export in the server in one of these paths:"
+#: ../templates/import_content.pt:59
+msgid "server_paths_list_hierarchical"
+msgstr ""
+
+#. Default: "Import from a directory that holds individual json-files per item:"
+#: ../templates/import_content.pt:43
+msgid "server_paths_list_per_json_file"
+msgstr ""
+
+#: ../export_content.py:126
 msgid "unlimited"
 msgstr ""

--- a/src/collective/exportimport/locales/es/LC_MESSAGES/collective.exportimport.po
+++ b/src/collective/exportimport/locales/es/LC_MESSAGES/collective.exportimport.po
@@ -2,460 +2,511 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.exportimport\n"
-"POT-Creation-Date: 2023-02-17 02:33+0000\n"
+"POT-Creation-Date: 2023-10-13 22:12+0000\n"
 "PO-Revision-Date: 2023-02-16 22:41-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Virtaal 0.7.1\n"
 "Language-Code: es\n"
 "Language-Name: Español\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.exportimport\n"
+"Language: es\n"
+"X-Generator: Virtaal 0.7.1\n"
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 
-#: collective/exportimport/import_content.py:961
-msgid "<p>Creation- and modification-dates are changed during import.This resets them to the original dates of the imported content.</p>"
-msgstr ""
-"<p>Las fechas de creación y modificación se cambian durante la importación. "
-"Esto las restablece a las fechas originales del contenido importado.</p>"
+#: ../templates/import_content.pt:99
+msgid "# Elements"
+msgstr "Nº elementos"
 
-#: collective/exportimport/import_content.py:992
+#: ../import_content.py:1069
+msgid "<p>Creation- and modification-dates are changed during import.This resets them to the original dates of the imported content.</p>"
+msgstr "<p>Las fechas de creación y modificación se cambian durante la importación. Esto las restablece a las fechas originales del contenido importado.</p>"
+
+#: ../import_content.py:1100
 msgid "<p>This fixes invalid collection-criteria that were imported from Plone 4 or 5.</p>"
 msgstr "<p>Esto corrige los criterios de recopilación no válidos que se importaron de Plone 4 o 5.</p>"
 
-#: collective/exportimport/templates/import_redirects.pt:32
+#: ../templates/import_redirects.pt:32
 msgid "Beware that this import would work only if you keep the same Plone site id and location in the site !"
-msgstr ""
-"¡Tenga en cuenta que esta importación solo funcionaría si mantiene la misma "
-"identificación y ubicación del sitio de Plone en el sitio!"
+msgstr "¡Tenga en cuenta que esta importación solo funcionaría si mantiene la misma identificación y ubicación del sitio de Plone en el sitio!"
 
-#: collective/exportimport/import_other.py:517
+#: ../import_other.py:521
 msgid "Changed {} default pages"
 msgstr "Se cambiaron {} páginas predeterminadas"
 
-#: collective/exportimport/templates/import_content.pt:30
+#: ../templates/export_content.pt:154
+msgid "Checking this box puts a list of object paths at the end of the export file that failed to export."
+msgstr "Seleccionar esta opción pone una lista de rutas, de objetos cuya exportación falló, al final del archivo de exportación"
+
+#: ../templates/import_content.pt:33
 msgid "Choose one"
 msgstr "Elige uno"
 
-#: collective/exportimport/templates/export_content.pt:19
+#: ../templates/export_content.pt:19
 msgid "Content Types to export"
 msgstr "Tipos de contenido para exportar"
 
-#: collective/exportimport/import_other.py:687
+#: ../import_other.py:690
 msgid "Created {} portlets"
 msgstr "Creados {} portlets"
 
-#: collective/exportimport/templates/export_content.pt:71
+#: ../templates/export_content.pt:77
 msgid "Depth"
 msgstr "Profundidad"
 
-#: collective/exportimport/templates/import_content.pt:56
+#: ../templates/import_content.pt:46
+msgid "Directory on server to import:"
+msgstr "Directorio del servidor desde el que importar"
+
+#: ../templates/import_content.pt:97
 msgid "Do a commit after each number of items"
 msgstr "Haz una confirmación después de cada número de elementos"
 
-#: collective/exportimport/templates/export_content.pt:139
-#: collective/exportimport/templates/export_other.pt:19
+#: ../templates/export_content.pt:162
+#: ../templates/export_other.pt:19
 msgid "Download to local machine"
 msgstr "Descargar a la máquina local"
 
-#: collective/exportimport/import_content.py:179
+#: ../import_content.py:213
 msgid "Exception during upload: {}"
 msgstr "Excepción durante la carga: {}"
 
-#: collective/exportimport/templates/export_content.pt:155
-#: collective/exportimport/templates/export_other.pt:32
+#: ../templates/export_content.pt:190
+#: ../templates/export_other.pt:32
 msgid "Export"
 msgstr "Exportar"
 
-#: collective/exportimport/export_other.py:585
-#: collective/exportimport/templates/links.pt:38
+#: ../export_other.py:587
+#: ../templates/links.pt:38
 msgid "Export comments"
 msgstr "Exportar comentarios"
 
-#: collective/exportimport/templates/export_content.pt:11
-#: collective/exportimport/templates/links.pt:10
+#: ../templates/export_content.pt:11
+#: ../templates/links.pt:10
 msgid "Export content"
 msgstr "Exportar contenido"
 
-#: collective/exportimport/export_other.py:506
-#: collective/exportimport/templates/links.pt:30
+#: ../export_other.py:508
+#: ../templates/links.pt:30
 msgid "Export default pages"
 msgstr "Exportar páginas predeterminadas"
 
-#: collective/exportimport/export_other.py:413
-#: collective/exportimport/templates/links.pt:26
+#: ../export_other.py:415
+#: ../templates/links.pt:26
 msgid "Export local roles"
 msgstr "Exportar roles locales"
 
-#: collective/exportimport/templates/links.pt:22
+#: ../templates/links.pt:22
 msgid "Export members"
 msgstr "Exportar miembros"
 
-#: collective/exportimport/export_other.py:233
+#: ../export_other.py:235
 msgid "Export members, groups and roles"
 msgstr "Exportar miembros, grupos y roles"
 
-#: collective/exportimport/templates/links.pt:34
+#: ../templates/links.pt:34
 msgid "Export object positions in parent"
 msgstr "Exportar posiciones de objetos en el padre"
 
-#: collective/exportimport/export_other.py:470
+#: ../export_other.py:472
 msgid "Export ordering"
 msgstr "Exportar ordenamiento"
 
-#: collective/exportimport/export_other.py:624
-#: collective/exportimport/templates/links.pt:42
+#: ../export_other.py:628
+#: ../templates/links.pt:42
 msgid "Export portlets"
 msgstr "Exportar portlets"
 
-#: collective/exportimport/export_other.py:759
-#: collective/exportimport/templates/links.pt:46
+#: ../export_other.py:779
+#: ../templates/links.pt:46
 msgid "Export redirects"
 msgstr "Exportar redireccionamientos"
 
-#: collective/exportimport/export_other.py:125
-#: collective/exportimport/templates/links.pt:14
+#: ../export_other.py:127
+#: ../templates/links.pt:14
 msgid "Export relations"
 msgstr "Exportar relaciones"
 
-#: collective/exportimport/export_other.py:331
-#: collective/exportimport/templates/links.pt:18
+#: ../export_other.py:333
+#: ../templates/links.pt:18
 msgid "Export translations"
 msgstr "Exportar traducciones"
 
-#: collective/exportimport/export_other.py:101
+#: ../export_other.py:103
 msgid "Exported to {}"
 msgstr "Exportado a {}"
 
-#: collective/exportimport/export_content.py:198
-msgid "Exported {} items ({}) as {} to {}"
-msgstr "Exportado {} elementos ({}) como {} a {}"
+#: ../export_content.py:271
+msgid "Exported {} items ({}) as {} to {} with {} errors"
+msgstr "Exportados {} elementos ({}) como {} a {} con {} errores"
 
-#: collective/exportimport/export_content.py:222
-msgid "Exported {} {}"
-msgstr "Exportado {} {}"
+#: ../export_content.py:213
+msgid "Exported {} items ({}) to {} with {} errors"
+msgstr "Exportados {} elementos ({}) en {} con {} errores"
 
-#: collective/exportimport/templates/links.pt:8
+#: ../export_content.py:299
+msgid "Exported {} {} with {} errors"
+msgstr "Exportado {} {} con {} errores"
+
+#: ../templates/links.pt:8
 msgid "Exports"
 msgstr "Exportaciones"
 
-#: collective/exportimport/import_other.py:91
+#: ../import_other.py:93
 msgid "Failure while uploading: {}"
 msgstr "Error al cargar: {}"
 
-#: collective/exportimport/import_content.py:160
+#: ../import_content.py:194
 msgid "File '{}' not found on server."
 msgstr "Archivo '{}' no encontrado en el servidor."
 
-#: collective/exportimport/templates/import_content.pt:27
+#: ../templates/import_content.pt:30
 msgid "File on server to import:"
 msgstr "Archivo en el servidor para importar:"
 
-#: collective/exportimport/import_content.py:1006
+#: ../import_content.py:1114
 msgid "Finished fixing collection queries."
 msgstr "Se terminaron de arreglar las consultas de colección."
 
-#: collective/exportimport/import_content.py:969
+#: ../import_content.py:1077
 msgid "Finished resetting creation and modification dates."
 msgstr "Finalizó el restablecimiento de las fechas de creación y modificación."
 
-#: collective/exportimport/import_content.py:991
-#: collective/exportimport/templates/links.pt:97
+#: ../import_content.py:1099
+#: ../templates/links.pt:97
 msgid "Fix collection queries"
 msgstr "Arreglar consultas de colección"
 
-#: collective/exportimport/fix_html.py:43
-#: collective/exportimport/templates/links.pt:101
+#: ../fix_html.py:43
+#: ../templates/links.pt:101
 msgid "Fix links to content and images in richtext"
 msgstr "Corregir enlaces a contenido e imágenes en texto enriquecido"
 
-#: collective/exportimport/fix_html.py:51
+#: ../fix_html.py:51
 msgid "Fixed HTML for {} fields in content items"
 msgstr "HTML corregido para {} campos en elementos de contenido"
 
-#: collective/exportimport/fix_html.py:55
+#: ../fix_html.py:55
 msgid "Fixed HTML for {} portlets"
 msgstr "HTML corregido para {} portlets"
 
-#: collective/exportimport/templates/import_content.pt:38
+#: ../templates/export_content.pt:180
+msgid "Generate a file for each item (as filesytem tree)"
+msgstr "Generar un archivo por cada elemento (exportación jerárquica en el sistema de archivos)"
+
+#: ../templates/import_content.pt:79
 msgid "Handle existing content"
 msgstr "Manejar el contenido existente"
 
-#: collective/exportimport/templates/export_other.pt:44
-#: collective/exportimport/templates/import_defaultpages.pt:31
-#: collective/exportimport/templates/import_discussion.pt:31
+#: ../templates/export_other.pt:44
+#: ../templates/import_defaultpages.pt:31
+#: ../templates/import_discussion.pt:31
 msgid "Help"
 msgstr "Ayuda"
 
-#: collective/exportimport/templates/import_defaultpages.pt:32
-#: collective/exportimport/templates/import_discussion.pt:32
-#: collective/exportimport/templates/import_localroles.pt:32
+#: ../templates/import_defaultpages.pt:32
+#: ../templates/import_discussion.pt:32
+#: ../templates/import_localroles.pt:32
 msgid "Here is a example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr "Aquí hay un ejemplo para el formato esperado. Este es el formato creado por el collective.exportimport cuando se utiliza para la exportación."
 
-#: collective/exportimport/templates/import_redirects.pt:34
+#: ../templates/import_redirects.pt:34
 msgid "Here is an example for the expected format. This is the format created by collective.exportimport when used for export."
 msgstr "Aquí hay un ejemplo para el formato esperado. Este es el formato creado por el collective.exportimport cuando se utiliza para la exportación."
 
-#: collective/exportimport/templates/import_content.pt:13
-#: collective/exportimport/templates/import_defaultpages.pt:13
-#: collective/exportimport/templates/import_discussion.pt:13
+#: ../templates/import_content.pt:15
+#: ../templates/import_defaultpages.pt:13
+#: ../templates/import_discussion.pt:13
 msgid "Here you can upload a json-file."
 msgstr "Aquí puede cargar un archivo json."
 
-#: collective/exportimport/templates/import_content.pt:39
+#: ../templates/import_content.pt:90
 msgid "How should content be handled that exists with the same id/path?"
 msgstr "¿Cómo se debe manejar el contenido que existe con el mismo id/path?"
 
-#: collective/exportimport/templates/export_content.pt:88
+#: ../templates/export_content.pt:105
 msgid "How should data from image- and file-fields be included?"
 msgstr "¿Cómo se deben incluir los datos de los campos de imagen y archivo?"
 
-#: collective/exportimport/import_content.py:127
+#: ../import_content.py:161
 msgid "Ignore: Create with a new id"
 msgstr "Ignorar: Crear con un nuevo id"
 
-#: collective/exportimport/templates/import_content.pt:92
-#: collective/exportimport/templates/import_defaultpages.pt:20
-#: collective/exportimport/templates/import_discussion.pt:20
+#: ../templates/import_content.pt:134
+#: ../templates/import_defaultpages.pt:20
+#: ../templates/import_discussion.pt:20
 msgid "Import"
 msgstr "Importar"
 
-#: collective/exportimport/templates/import_content.pt:11
+#: ../templates/import_content.pt:11
 msgid "Import Content"
 msgstr "Importar Contenido"
 
-#: collective/exportimport/templates/import_defaultpages.pt:11
+#: ../templates/import_defaultpages.pt:11
 msgid "Import Default Pages"
 msgstr "Importar páginas predeterminadas"
 
-#: collective/exportimport/templates/import_discussion.pt:11
+#: ../templates/import_discussion.pt:11
 msgid "Import Discussion"
 msgstr "Importar discusión"
 
-#: collective/exportimport/templates/import_localroles.pt:11
+#: ../templates/import_localroles.pt:11
 msgid "Import Localroles"
 msgstr "Importar roles locales"
 
-#: collective/exportimport/templates/import_members.pt:11
+#: ../templates/import_members.pt:11
 msgid "Import Members, Groups and their Roles"
 msgstr "Importar miembros, grupos y sus roles"
 
-#: collective/exportimport/templates/import_ordering.pt:11
+#: ../templates/import_ordering.pt:11
 msgid "Import Object Positions in Parent"
 msgstr "Importar posiciones de objetos en el padre"
 
-#: collective/exportimport/templates/import_redirects.pt:11
+#: ../templates/import_redirects.pt:11
 msgid "Import Redirects"
 msgstr "Importar redireccionamientos"
 
-#: collective/exportimport/templates/import_relations.pt:11
+#: ../templates/import_relations.pt:11
 msgid "Import Relations"
 msgstr "Importar relaciones"
 
-#: collective/exportimport/templates/import_content.pt:71
+#: ../templates/import_content.pt:113
 msgid "Import all items into the current folder"
 msgstr "Importar todos los elementos a la carpeta actual"
 
-#: collective/exportimport/templates/import_content.pt:83
+#: ../templates/import_content.pt:125
 msgid "Import all old revisions"
 msgstr "Importar todas las revisiones antiguas"
 
-#: collective/exportimport/templates/links.pt:81
+#: ../templates/links.pt:81
 msgid "Import comments"
 msgstr "Importar comentarios"
 
-#: collective/exportimport/templates/links.pt:53
+#: ../templates/links.pt:53
 msgid "Import content"
 msgstr "Importar contenido"
 
-#: collective/exportimport/templates/links.pt:73
+#: ../templates/links.pt:73
 msgid "Import default pages"
 msgstr "Importar páginas predeterminadas"
 
-#: collective/exportimport/templates/links.pt:69
+#: ../templates/links.pt:69
 msgid "Import local roles"
 msgstr "Importar roles locales"
 
-#: collective/exportimport/templates/links.pt:65
+#: ../templates/links.pt:65
 msgid "Import members"
 msgstr "Importar miembros"
 
-#: collective/exportimport/templates/links.pt:77
+#: ../templates/links.pt:77
 msgid "Import object positions in parent"
 msgstr "Importar posiciones de objetos en el padre"
 
-#: collective/exportimport/templates/import_portlets.pt:11
-#: collective/exportimport/templates/links.pt:85
+#: ../templates/import_portlets.pt:11
+#: ../templates/links.pt:85
 msgid "Import portlets"
 msgstr "Importar portlets"
 
-#: collective/exportimport/templates/links.pt:89
+#: ../templates/links.pt:89
 msgid "Import redirects"
 msgstr "Importar redireccionamientos"
 
-#: collective/exportimport/templates/links.pt:57
+#: ../templates/links.pt:57
 msgid "Import relations"
 msgstr "Importar relaciones"
 
-#: collective/exportimport/templates/import_translations.pt:11
-#: collective/exportimport/templates/links.pt:61
+#: ../templates/import_translations.pt:11
+#: ../templates/links.pt:61
 msgid "Import translations"
 msgstr "Importar traducciones"
 
-#: collective/exportimport/import_other.py:590
+#: ../import_other.py:594
 msgid "Imported {} comments"
 msgstr "Importados {} comentarios"
 
-#: collective/exportimport/import_other.py:201
+#: ../import_other.py:203
 msgid "Imported {} groups and {} members"
 msgstr "Importados {} grupos y {} miembros"
 
-#: collective/exportimport/import_other.py:392
+#: ../import_other.py:393
 msgid "Imported {} localroles"
 msgstr "Importados {} roles locales"
 
-#: collective/exportimport/import_other.py:464
+#: ../import_other.py:468
 msgid "Imported {} orders in {} seconds"
 msgstr "Importados {} ordenes en {} segundos"
 
-#: collective/exportimport/templates/links.pt:51
+#: ../templates/links.pt:51
 msgid "Imports"
 msgstr "Importaciones"
 
-#: collective/exportimport/templates/export_content.pt:87
+#: ../templates/export_content.pt:94
 msgid "Include blobs"
 msgstr "Incluir blobs"
 
-#: collective/exportimport/templates/export_content.pt:129
+#: ../templates/export_content.pt:136
 msgid "Include revisions."
 msgstr "Incluir revisiones."
 
-#: collective/exportimport/templates/export_content.pt:113
+#: ../templates/export_content.pt:120
 msgid "Modify exported data for migrations."
 msgstr "Modificar datos exportados para migraciones."
 
-#: collective/exportimport/templates/import_redirects.pt:33
+#: ../templates/import_redirects.pt:33
 msgid "More code is needed if you have another use case."
 msgstr "Se necesita más código si tiene otro caso de uso."
 
-#: collective/exportimport/export_other.py:84
+#: ../export_other.py:86
 msgid "No data to export for {}"
 msgstr "No hay datos para exportar {}"
 
-#: collective/exportimport/templates/import_content.pt:25
-msgid "No files found."
-msgstr "No se encontraron archivos."
+#: ../templates/import_content.pt:44
+msgid "No directories to import from found."
+msgstr "No se han encontrado directorios desde los que importar."
 
-#: collective/exportimport/templates/export_content.pt:63
+#: ../templates/import_content.pt:28
+msgid "No json-files found."
+msgstr "No se han encontrado archivos json."
+
+#: ../templates/import_content.pt:77
+msgid "Options"
+msgstr "Opciones"
+
+#: ../templates/export_content.pt:69
 msgid "Path"
 msgstr "Ruta"
 
-#: collective/exportimport/import_other.py:822
+#: ../import_other.py:873
 msgid "Redirects imported"
 msgstr "Redirecciones importadas"
 
-#: collective/exportimport/import_content.py:125
+#: ../import_content.py:159
 msgid "Replace: Delete item and create new"
 msgstr "Reemplazar: Eliminar elemento y crear nuevo"
 
-#: collective/exportimport/templates/links.pt:93
+#: ../templates/links.pt:93
 msgid "Reset created and modified dates"
 msgstr "Restablecer fechas de creación y modificación"
 
-#: collective/exportimport/import_content.py:960
+#: ../import_content.py:1068
 msgid "Reset creation and modification date"
 msgstr "Restablecer fecha de creación y modificación"
 
-#: collective/exportimport/templates/export_content.pt:145
-#: collective/exportimport/templates/export_other.pt:25
+#: ../templates/export_content.pt:174
+msgid "Save each item as a separate file on the server"
+msgstr "Guardar, en el servidor, cada elemento en un archivo json independiente"
+
+#: ../templates/export_content.pt:168
+#: ../templates/export_other.pt:25
 msgid "Save to file on server"
 msgstr "Guardar en un archivo en el servidor"
 
-#: collective/exportimport/templates/export_content.pt:24
+#: ../templates/export_content.pt:25
 msgid "Select all/none"
 msgstr "Seleccionar todo/ninguno"
 
-#: collective/exportimport/export_content.py:150
+#: ../export_content.py:154
 msgid "Select at least one type to export"
 msgstr "Seleccione al menos un tipo para exportar"
 
-#: collective/exportimport/templates/export_content.pt:13
+#: ../templates/export_content.pt:13
 msgid "Select which content to export as a json-file."
 msgstr "Seleccione qué contenido exportar como un archivo json."
 
-#: collective/exportimport/import_content.py:124
+#: ../import_content.py:158
 msgid "Skip: Don't import at all"
 msgstr "Omitir: no importar en absoluto"
 
-#: collective/exportimport/templates/export_content.pt:130
+#: ../templates/export_content.pt:138
 msgid "This exports the content-history (versioning) of each exported item. Warning: This can significantly slow down the export!"
 msgstr "Esto exporta el historial de contenido (versiones) de cada elemento exportado. Advertencia: ¡Esto puede ralentizar significativamente la exportación!"
 
-#: collective/exportimport/templates/import_content.pt:84
+#: ../templates/import_content.pt:127
 msgid "This will import the content-history (versioning) for each item that has revisions. Warning: This can significantly slow down the import!"
 msgstr "Esto importará el historial de contenido (versiones) para cada elemento que tenga revisiones. Advertencia: ¡Esto puede ralentizar significativamente la importación!"
 
-#: collective/exportimport/templates/export_content.pt:72
+#: ../templates/export_content.pt:88
 msgid "Unlimited: this item and all children, 0: this object only, 1: only direct children of this object, 2-x: children of this object up to the specified level"
-msgstr ""
-"Ilimitado: este elemento y todos los elementos secundarios, 0: solo este "
-"objeto, 1: solo elementos secundarios directos de este objeto, 2-x: "
-"elementos secundarios de este objeto hasta el nivel especificado"
+msgstr "Ilimitado: este elemento y todos los elementos secundarios, 0: solo este objeto, 1: solo elementos secundarios directos de este objeto, 2-x: elementos secundarios de este objeto hasta el nivel especificado"
 
-#: collective/exportimport/import_content.py:126
+#: ../import_content.py:160
 msgid "Update: Reuse and only overwrite imported data"
 msgstr "Actualizar: reutilizar y solo sobrescribir datos importados"
 
-#: collective/exportimport/templates/export_content.pt:114
+#: ../templates/export_content.pt:122
 msgid "Use this if you want to import the data in a newer version of Plone or migrate from Archetypes to Dexterity. Read the documentation to learn which changes are made by this option."
 msgstr "Use esto si desea importar los datos en una versión más nueva de Plone o migrar de Archetypes a Dexterity. Lea la documentación para saber qué cambios se realizan con esta opción."
 
-#: collective/exportimport/import_other.py:288
+#: ../templates/export_content.pt:152
+msgid "Write out Errors to file."
+msgstr "Escribir los errores en el fichero."
+
+#: ../templates/import_content.pt:21
+msgid "You can also select a json-file or a directory holding json-files on the server in the following locations:"
+msgstr "Puede seleccionar un archivo json o un directorio que contenga los archivos json independientes entre las siguientes ubicaciones:"
+
+#: ../import_other.py:289
 msgid "You need either Plone 6 or collective.relationhelpers to import relations"
 msgstr "Necesitas Plone 6 o collective.relationhelpers para importar relaciones"
 
-#: collective/exportimport/export_content.py:139
+#: ../export_content.py:142
 msgid "as base-64 encoded strings"
 msgstr "como cadenas codificadas en base 64"
 
-#: collective/exportimport/export_content.py:140
+#: ../export_content.py:143
 msgid "as blob paths"
 msgstr "como rutas de blob"
 
-#: collective/exportimport/export_content.py:138
+#: ../export_content.py:141
 msgid "as download urls"
 msgstr "como urls de descarga"
 
-#: collective/exportimport/templates/export_content.pt:155
+#. Default: "Deleted ${items} items."
+#: ../filesystem_importer.py:135
+msgid "deleted_items_msg"
+msgstr "Eliminados ${items} elementos."
+
+#: ../templates/export_content.pt:190
 msgid "export"
 msgstr "exportar"
 
-#: collective/exportimport/import_content.py:143
+#. Default: "Exported ${number} items (${types}) as tree to ${target} with ${errors} errors"
+#: ../export_content.py:233
+msgid "hierarchycal_export_success"
+msgstr "Se han exportado ${number} elementos (${types}) como árbol en ${target} con ${errors} errores"
+
+#: ../import_content.py:177
 msgid "json file was uploaded, so the selected server file was ignored."
 msgstr "archivo json se cargó, por lo que se ignoró el archivo del servidor seleccionado."
 
 #. Default: "Toggle all"
-#: collective/exportimport/templates/export_content.pt:22
+#: ../templates/export_content.pt:23
 msgid "label_toggle"
 msgstr "Alternar todo"
 
-#: collective/exportimport/import_content.py:996
+#: ../import_content.py:1104
 msgid "plone.app.querystring.upgrades.fix_select_all_existing_collections is not available"
 msgstr "plone.app.querystring.upgrades.fix_select_all_existing_collections no está disponible"
 
-#. Default: "Or you can choose a file that is already uploaded on the server in one of these paths:"
-#: collective/exportimport/templates/import_content.pt:21
+#. Default: "Import from a json-file"
+#: ../templates/import_content.pt:27
 msgid "server_paths_list"
-msgstr ""
-"O puede elegir un archivo que ya está cargado en el servidor en una de estas "
-"rutas:"
+msgstr "O puede elegir un archivo que ya está cargado en el servidor en una de estas rutas:"
 
-#: collective/exportimport/export_content.py:123
+#. Default: "Or you can choose from a tree export in the server in one of these paths:"
+#: ../templates/import_content.pt:59
+msgid "server_paths_list_hierarchical"
+msgstr "O puede elegir desde que exportación jerárquica del servidor entre una de estas rutas:"
+
+#. Default: "Import from a directory that holds individual json-files per item:"
+#: ../templates/import_content.pt:43
+msgid "server_paths_list_per_json_file"
+msgstr "Importar desde un directorio que contiene archivos json únicos por elemento."
+
+#: ../export_content.py:126
 msgid "unlimited"
 msgstr "ilimitado"

--- a/src/collective/exportimport/templates/export_content.pt
+++ b/src/collective/exportimport/templates/export_content.pt
@@ -19,59 +19,64 @@
                 <span i18n:translate="">Content Types to export</span>
               </label>
               <div class="widget" id="portal_type">
-                <input type="checkbox" class="checkboxType" name="checkall" id="checkall"
-                       title="Toggle all" i18n:attributes="title label_toggle" />
-                <label for="checkall"><i i18n:translate="">Select all/none</i></label><br />
-                <script type="text/javascript">
-                   // Check or Uncheck All checkboxes
-                   $("#checkall").change(function(){
-                     var checked = $(this).is(':checked');
-                     if(checked){
-                       $("form#export_content #portal_type input[type='checkbox']").each(function(){
-                         $(this).prop("checked",true);
-                       });
-                     }else{
-                       $("form#export_content #portal_type input[type='checkbox']").each(function(){
-                         $(this).prop("checked",false);
-                       });
-                     }
-                   });
+                <div class="form-check form-switch">
+                  <input type="checkbox" class="checkboxType form-check-input" name="checkall" id="checkall"
+                    title="Toggle all" i18n:attributes="title label_toggle" />
+                  <label for="checkall form-check-label"><i i18n:translate="">Select all/none</i></label><br />
+                  <script type="text/javascript">
+                      // Check or Uncheck All checkboxes
+                      $("#checkall").change(function(){
+                        var checked = $(this).is(':checked');
+                        if(checked){
+                          $("form#export_content #portal_type input[type='checkbox']").each(function(){
+                            $(this).prop("checked",true);
+                          });
+                        }else{
+                          $("form#export_content #portal_type input[type='checkbox']").each(function(){
+                            $(this).prop("checked",false);
+                          });
+                        }
+                      });
 
-                  // Changing state of CheckAll checkbox
-                  $("form#export_content").on("click", "form#export_content #portal_type input[name='portal_type']", function(){
-                    if($("form#export_content #portal_type input[type='checkbox']").length == $("form#export_content #portal_type input[type='checkbox']:checked").length) {
-                      $("#checkall").prop("checked", true);
-                    } else {
-                      $("#checkall").prop("checked", false);
-                    }
+                    // Changing state of CheckAll checkbox
+                    $("form#export_content").on("click", "form#export_content #portal_type input[name='portal_type']", function(){
+                      if($("form#export_content #portal_type input[type='checkbox']").length == $("form#export_content #portal_type input[type='checkbox']:checked").length) {
+                        $("#checkall").prop("checked", true);
+                      } else {
+                        $("#checkall").prop("checked", false);
+                      }
 
-                  });
-                </script>
+                    });
+                  </script>
+                </div>
+
                 <tal:types tal:repeat="ptype python: view.portal_types()">
-                  <input type="checkbox"
-                         name="portal_type"
-                         class="checkboxType"
-                         tal:attributes="value ptype/value; id ptype/value;">
-                  <label tal:attributes="for ptype/value"
-                         tal:content="string:${ptype/title} - ${ptype/value} (${ptype/number})"></label>
-                         <br />
+                  <div class="form-check form-switch">
+                    <input type="checkbox"
+                      name="portal_type"
+                      class="checkboxType form-check-input"
+                      tal:attributes="value ptype/value; id ptype/value;">
+                    <label class="form-check-label"
+                      tal:attributes="for ptype/value"
+                      tal:content="string:${ptype/title} - ${ptype/value} (${ptype/number})"></label>
+                      <br />
+                  </div>
                 </tal:types>
               </div>
             </div>
 
             <div class="field mb-3">
-              <label for="path" i18n:translate="">Path</label>
+              <label for="path" class="form-label" i18n:translate="">Path</label>
               <div class="widget">
-                <input type="text" name="path" id="path" value=""
+                <input type="text" name="path" id="path" value="" class="form-control"
                        tal:attributes="value python:view.path">
               </div>
             </div>
 
             <div class="field mb-3">
-              <label for="depth" i18n:translate="">Depth</label>
-              <span class="formHelp" i18n:translate="">Unlimited: this item and all children, 0: this object only, 1: only direct children of this object, 2-x: children of this object up to the specified level</span>
+              <label for="depth" class="form-label" i18n:translate="">Depth</label>
               <div class="widget">
-                <select name="depth" class="">
+                <select name="depth" class="form-select">
                   <option value="1"
                           tal:repeat="current python:view.depth_options"
                           tal:attributes="value python: current[0];
@@ -80,16 +85,15 @@
                         1
                   </option>
                 </select>
+                <div class="formHelp form-text" i18n:translate="">
+                  Unlimited: this item and all children, 0: this object only, 1: only direct children of this object, 2-x: children of this object up to the specified level</div>
               </div>
             </div>
 
             <div class="field mb-3">
-              <label for="include_blobs" i18n:translate="">Include blobs</label>
-              <span class="formHelp" i18n:translate="">
-                  How should data from image- and file-fields be included?
-              </span>
+              <label for="include_blobs" class="form-label" i18n:translate="">Include blobs</label>
               <div class="widget">
-                <select name="include_blobs" class="">
+                <select name="include_blobs" class="form-select">
                   <option value="0"
                           tal:repeat="current python:view.include_blobs_options"
                           tal:attributes="value python: current[0];
@@ -98,27 +102,29 @@
                         0
                   </option>
                 </select>
+                <span class="formHelp form-text" i18n:translate="">
+                  How should data from image- and file-fields be included?
+              </span>
               </div>
             </div>
 
-            <div class="field mb-3">
-              <label>
-                <input
-                    type="checkbox"
-                    class="form-check-input"
-                    name="migration:boolean"
-                    id="migration"
-                    tal:attributes="checked python: 'checked' if view.migration else None"
-                    />
+            <div class="field mb-3 form-check form-switch">
+              <input
+                  type="checkbox"
+                  class="form-check-input"
+                  name="migration:boolean"
+                  id="migration"
+                  tal:attributes="checked python: 'checked' if view.migration else None"
+                  />
+              <label class="form-check-label">
                 <span i18n:translate="">Modify exported data for migrations.</span>
-                <span class="formHelp" i18n:translate="">
-                  Use this if you want to import the data in a newer version of Plone or migrate from Archetypes to Dexterity. Read the documentation to learn which changes are made by this option.
-                </span>
               </label>
+              <div class="formHelp form-text" i18n:translate="">
+                Use this if you want to import the data in a newer version of Plone or migrate from Archetypes to Dexterity. Read the documentation to learn which changes are made by this option.
+              </div>
             </div>
 
-            <div class="field mb-3">
-              <label>
+            <div class="field mb-3 form-check form-switch">
                 <input
                     type="checkbox"
                     class="form-check-input"
@@ -126,15 +132,15 @@
                     id="include_revisions"
                     tal:attributes="checked python: 'checked' if view.include_revisions else None"
                     />
+              <label class="form-check-label" for="include_revisions">
                 <span i18n:translate="">Include revisions.</span>
-                <span class="formHelp" i18n:translate="">
-                  This exports the content-history (versioning) of each exported item. Warning: This can significantly slow down the export!
-                </span>
               </label>
+              <div class="formHelp form-text" i18n:translate="">
+                This exports the content-history (versioning) of each exported item. Warning: This can significantly slow down the export!
+              </div>
             </div>
 
-            <div class="field mb-3">
-              <label>
+            <div class="field mb-3 form-check form-switch">
                 <input
                     type="checkbox"
                     class="form-check-input"
@@ -142,30 +148,37 @@
                     id="write_errors"
                     tal:attributes="checked python: 'checked' if view.write_errors else None"
                     />
+              <label class="form-check-label">
                 <span i18n:translate="">Write out Errors to file.</span>
-                <span class="formHelp" i18n:translate="">
-                  Checking this box puts a list of object paths at the end of the export file that failed to export.
-                </span>
               </label>
+              <div class="formHelp form-text" i18n:translate="">
+                Checking this box puts a list of object paths at the end of the export file that failed to export.
+              </div>
             </div>
 
             <div class="field mb-3">
-              <div class="form-check">
+              <div class="form-check mb-2">
                 <input class="form-check-input" type="radio" name="download_to_server:int" value="0" id="download_local" checked="checked">
                 <label for="download_local" class="form-check-label" i18n:translate="">
                   Download to local machine
                 </label>
               </div>
-              <div class="form-check">
+              <div class="form-check mb-2">
                 <input class="form-check-input" type="radio" name="download_to_server:int" value="1" id="download_server">
                 <label for="download_server" class="form-check-label" i18n:translate="">
                   Save to file on server
                 </label>
               </div>
-              <div class="form-check">
+              <div class="form-check mb-2">
                 <input class="form-check-input" type="radio" name="download_to_server:int" value="2" id="separate_files">
                 <label for="separate_files" class="form-check-label" i18n:translate="">
                   Save each item as a separate file on the server
+                </label>
+              </div>
+              <div class="form-check mb-2">
+                <input class="form-check-input" type="radio" name="download_to_server:int" value="3" id="hierarchical_files">
+                <label for="hierarchical_files" class="form-check-label" i18n:translate="">
+                  Generate a file for each item (as filesytem tree)
                 </label>
               </div>
             </div>

--- a/src/collective/exportimport/templates/import_content.pt
+++ b/src/collective/exportimport/templates/import_content.pt
@@ -10,14 +10,15 @@
 
       <h1 class="documentFirstHeading" i18n:translate="">Import Content</h1>
 
-      <p class="documentDescription" i18n:translate="">Here you can upload a json-file.</p>
-
         <form action="." tal:attributes="action request/URL" method="post" enctype="multipart/form-data">
+          <fieldset class="mb-4">
+            <legend class="h5 border-bottom pb-1" i18n:translate="">Here you can upload a json-file.</legend>
             <div class="form-group">
-                <input type="file" name="jsonfile"/><br/>
+              <input class="form-control" type="file" name="jsonfile"/><br/>
             </div>
-
-            <p>You can also select a json-file or a directory holding json-files on the server in the following locations:</p>
+          </fieldset>
+          <fieldset class="mb-4">
+            <legend class="h5 border-bottom pb-1" i18n:translate="">You can also select a json-file or a directory holding json-files on the server in the following locations:</legend>
             <ul>
               <li tal:repeat="path view/import_paths"><code tal:content="path" /></li>
             </ul>
@@ -26,19 +27,21 @@
               <p i18n:translate="server_paths_list">Import from a json-file</p>
               <p tal:condition="not:server_files" i18n:translate="">No json-files found.</p>
               <div class="field mb-3" tal:condition="server_files">
-                <label for="server_file" i18n:translate="">json-file on server to import:</label>
+                <label class="form-label" for="server_file" i18n:translate="">File on server to import:</label>
                 <br />
-                <select id="server_file" name="server_file">
+                <select class="form-select" id="server_file" name="server_file">
                   <option selected="" value="" title="" i18n:translate="">Choose one</option>
                   <option tal:repeat="filename server_files" tal:content="filename" tal:attributes="value filename">
                   </option>
                 </select>
               </div>
             </tal:block>
+          </fieldset>
 
+          <fieldset class="mb-4">
             <tal:block define="server_directories view/server_directories">
-              <p i18n:translate="server_paths_list">Import from a directory that holds individual json-files per item:</p>
-              <p tal:condition="not:server_directories" i18n:translate="">No directories to import from found.</p>
+              <legend class="h5 border-bottom pb-1" i18n:translate="server_paths_list_per_json_file">Import from a directory that holds individual json-files per item:</legend>
+              <p class="alert alert-danger" tal:condition="not:server_directories" i18n:translate="">No directories to import from found.</p>
               <div class="field mb-3" tal:condition="server_directories">
                 <label for="server_directory" i18n:translate="">Directory on server to import:</label>
                 <br />
@@ -49,14 +52,33 @@
                 </select>
               </div>
             </tal:block>
+          </fieldset>
 
+          <fieldset class="mb-4">
+            <tal:block define="server_files view/import_tree_parts">
+              <legend class="h5 border-bottom pb-1" i18n:translate="server_paths_list_hierarchical">Or you can choose from a tree export in the server in one of these paths:</legend>
+              <ul>
+                <li tal:repeat="path view/import_tree_parts"><code tal:content="path" /></li>
+              </ul>
+              <p class="alert alert-danger" tal:condition="not:server_files" i18n:translate="">No directories to import from found.</p>
+              <div class="field mb-3" tal:condition="server_files">
+                <label class="form-label" for="server_file" i18n:translate="">File on server to import:</label>
+                <br />
+                <select class="form-select" id="server_tree_file" name="server_tree_file">
+                  <option selected="" value="" title="" i18n:translate="">Choose one</option>
+                  <option tal:repeat="filename server_files" tal:content="filename" tal:attributes="value filename">
+                  </option>
+                </select>
+              </div>
+            </tal:block>
+          </fieldset>
+
+          <fieldset class="mb-4">
+            <legend class="h5 border-bottom pb-1" i18n:translate="">Options</legend>
             <div class="field mb-3">
-              <label for="include_blobs" i18n:translate="">Handle existing content</label>
-              <span class="formHelp" i18n:translate="">
-                  How should content be handled that exists with the same id/path?
-              </span>
+              <label class="form-label" for="include_blobs" i18n:translate="">Handle existing content</label>
               <div class="widget">
-                <select name="handle_existing_content" class="">
+                <select class="form-select" name="handle_existing_content" class="">
                   <option value="0"
                           tal:repeat="current python:view.handle_existing_content_options"
                           tal:attributes="value python: current[0];
@@ -65,50 +87,54 @@
                         0
                   </option>
                 </select>
+                <div class="formHelp form-text" i18n:translate="">
+                  How should content be handled that exists with the same id/path?
+                </div>
               </div>
             </div>
 
             <div class="field mb-3">
-              <label for="commit" i18n:translate="">Do a commit after each number of items</label>
-              <div class="widget">
-                <input type="text" size="5" name="commit" id="commit" value=""
+              <label class="form-label" for="commit" i18n:translate="">Do a commit after each number of items</label>
+              <div class="widget input-group">
+                <span class="input-group-text" id="number-transactions" i18n:translate=""># Elements</span>
+                <input class="form-control" type="text" size="5" name="commit" id="commit" value=""
                        tal:attributes="value python:view.commit">
               </div>
             </div>
 
-            <div class="field">
-              <label>
-                <input
-                    type="checkbox"
-                    name="import_to_current_folder:boolean"
-                    id="import_to_current_folder"
-                    tal:attributes="checked python:'checked' if view.import_to_current_folder else None"
-                    />
+            <div class="field form-check form-switch">
+              <label class="form-check-label" >
+                <input class="form-check-input"
+                      type="checkbox"
+                      name="import_to_current_folder:boolean"
+                      id="import_to_current_folder"
+                      tal:attributes="checked python:'checked' if view.import_to_current_folder else None"
+                      />
                 <span i18n:translate="">Import all items into the current folder</span>
               </label>
             </div>
 
-            <div class="field">
-              <label>
-                <input
+            <div class="field form-check form-switch">
+              <label class="form-check-label" >
+                <input class="form-check-input"
                     type="checkbox"
                     name="import_old_revisions:boolean"
                     id="import_old_revisions"
                     tal:attributes="checked python:'checked' if view.import_old_revisions else None"
                     />
                 <span i18n:translate="">Import all old revisions</span>
-                <span class="formHelp" i18n:translate="">
-                  This will import the content-history (versioning) for each item that has revisions. Warning: This can significantly slow down the import!
-                </span>
               </label>
+              <div class="formHelp form-text" i18n:translate="">
+                This will import the content-history (versioning) for each item that has revisions. Warning: This can significantly slow down the import!
+              </div>
             </div>
-
-            <div class="formControls" class="form-group">
-                <input type="hidden" name="form.submitted" value="1"/>
-                <button class="btn btn-primary submit-widget button-field context"
-                        type="submit" name="submit" value="Import" i18n:attributes="value" i18n:translate="">Import
-                </button>
-            </div>
+          </fieldset>
+          <div class="formControls" class="form-group">
+              <input type="hidden" name="form.submitted" value="1"/>
+              <button class="btn btn-primary submit-widget button-field context"
+                      type="submit" name="submit" value="Import" i18n:attributes="value" i18n:translate="">Import
+              </button>
+          </div>
 
         </form>
 

--- a/src/collective/exportimport/tests/test_export_hierarchical.py
+++ b/src/collective/exportimport/tests/test_export_hierarchical.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+from collective.exportimport import config
+from collective.exportimport.testing import (
+    COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,  # noqa: E501,
+)
+from plone import api
+from plone.app.testing import login
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+
+import os
+import shutil
+import tempfile
+import transaction
+import unittest
+
+try:
+    from plone.testing import zope
+
+    OLD_ZOPE_TESTBROWSER = False
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    OLD_ZOPE_TESTBROWSER = True
+
+
+DATA = []
+
+
+def write(self, data):
+    """Override for HTTPResponse.write.
+
+    In Zope 2 (Plone 4.3-5.1) in tests, when we export content to download it,
+    the resulting browser.contents is empty, instead of containing json.
+    This is an ugly hack to capture the data that should be available.
+    I tried a few other ways, but failed.
+    """
+    self._orig_write(data)
+    DATA.append(data)
+
+
+class TestHierarchicalExport(unittest.TestCase):
+    """Test that we can export."""
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        if OLD_ZOPE_TESTBROWSER:
+            # patch HTTPResponse so we can get an attachment
+            HTTPResponse._orig_write = HTTPResponse.write
+            HTTPResponse.write = write
+
+    def tearDown(self):
+        if OLD_ZOPE_TESTBROWSER:
+            # undo patch
+            HTTPResponse.write = HTTPResponse._orig_write
+
+    def create_demo_content(self):
+        """Create a portal structure which we can test against.
+        Plone (portal root)
+        |-- folder1
+        |   |-- doc1
+        |   |-- folder2_1
+        |       |-- doc3
+        |-- folder2
+            |-- doc2
+        """
+        portal = self.layer["portal"]
+        folder1 = api.content.create(
+            container=portal, type="Folder", id="folder1", title="Folder 1"
+        )
+        doc1 = api.content.create(
+            container=folder1, type="Document", id="doc1", title="Document 1"
+        )
+        folder1._setProperty("default_page", "doc1")
+
+        folder2 = api.content.create(
+            container=portal, type="Folder", id="folder2", title="Folder 2"
+        )
+        folder2_1 = api.content.create(
+            container=folder1, type="Folder", id="folder2-1", title="Folder 2.1"
+        )
+        doc2 = api.content.create(
+            container=folder2, type="Document", id="doc2", title="Document 2"
+        )
+        doc3 = api.content.create(
+            container=folder2_1, type="Document", id="doc3", title="Document 3"
+        )
+
+    def open_page(self, page):
+        """Create a testbrowser, open a page, return the browser."""
+        browser = zope.Browser(self.layer["app"])
+        browser.handleErrors = False
+        browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        url = "/".join([self.layer["portal"].absolute_url(), page])
+        browser.open(url)
+        return browser
+
+    def test_export_content_page(self):
+        # Simply test that some text is on the page.
+        browser = self.open_page("@@export_content")
+        self.assertIn("Generate a file for each item (as filesytem tree)", browser.contents)
+
+    def test_export_all_content_to_server(self):
+        """Test complete hierarchical export to server"""
+
+        # 1. Create Content
+        # 2. Enter to the page
+        # 3. Select proper select
+        # 4. Select proper checkbox
+        # 5. Set central original_central_directory
+        # 6. Submit form
+        # 7. Check base directories
+        # 8. Check exported tree contains content
+        # 9. Finally, remove exported directory
+
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        fti = self.layer["portal"].portal_types["Plone Site"]
+
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+
+        transaction.commit()
+
+        # Go to export_content view
+        browser = self.open_page("@@export_content")
+
+        # Now export all.
+        portal_type = browser.getControl(name="portal_type")
+        self.assertEqual(portal_type.value, [])
+        self.assertIn("Document", portal_type.options)
+        self.assertIn("Folder", portal_type.options)
+
+        portal_type.value = ["Folder", "Document"]
+        fti = self.layer["portal"].portal_types["Plone Site"]
+        if "DexterityFTI" in repr(fti):
+            # In Plone 6 the portal is exportable
+            self.assertIn("Plone Site", portal_type.options)
+            portal_type.value = ["Folder", "Document"]
+
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit(name="submit")
+
+            msg = "Exported 6 items (Folder, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # check paths
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "content")
+            self.assertTrue(os.path.exists(path))
+
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "removed_items")
+            self.assertTrue(os.path.exists(path))
+
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "content",
+                "folder1",
+                "2_doc1.json")
+            self.assertTrue(os.path.exists(path))
+
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_export_partial_content_to_server(self):
+        """Test complete hierarchical export to server"""
+
+        # 1. Create Content
+        # 2. Enter to the page
+        # 3. Select proper content
+        # 4. Select proper checkbox
+        # 5. Set central original_central_directory
+        # 6. Submit form
+        # 7. Check base directories
+        # 8. Check exported tree contains content
+        # 9. Finally, remove exported directory
+
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        fti = self.layer["portal"].portal_types["Plone Site"]
+
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Go to export_content view
+        browser = self.open_page("@@export_content")
+
+        # Check content types and export folders.
+        portal_type = browser.getControl(name="portal_type")
+        self.assertEqual(portal_type.value, [])
+        self.assertIn("Document", portal_type.options)
+        self.assertIn("Folder", portal_type.options)
+
+        portal_type.value = ["Folder"]
+
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit(name="submit")
+
+            msg = "Exported 3 items (Folder) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # check paths
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "content")
+            self.assertTrue(os.path.exists(path))
+
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "removed_items")
+            self.assertTrue(os.path.exists(path))
+
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "content",
+                "folder1")
+            self.assertTrue(os.path.exists(path))
+
+            path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                "exported_tree",
+                portal.getId(),
+                "content",
+                "folder1",
+                "2_doc1.json")
+            self.assertFalse(os.path.exists(path))
+
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory

--- a/src/collective/exportimport/tests/test_filesystem_exporter.py
+++ b/src/collective/exportimport/tests/test_filesystem_exporter.py
@@ -1,0 +1,56 @@
+import unittest
+import tempfile
+import os
+import json
+import shutil
+from collective.exportimport import config
+from collective.exportimport.filesystem_exporter import FileSystemContentExporter
+from collective.exportimport.testing import COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+
+class TestFileSystemContentExporter(unittest.TestCase):
+    """Test the FileSystemContentExport class"""
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set up a temporary directory for testing
+        self.temp_dir = 'temp_test_directory'
+        os.makedirs(self.temp_dir)
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_save(self):
+
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            exporter = FileSystemContentExporter()
+            item = {
+                "id": "test_item",
+                "parent": {"@id": "/test_parent"},
+                "is_folderish": False
+                # Add other required fields as needed
+            }
+
+            exporter.save(1, item)
+
+            # Check if the file was created in the correct location
+            file_path = os.path.join(
+                config.CENTRAL_DIRECTORY,
+                'exported_tree',
+                'plone',
+                'content',
+                'test_parent',
+                '1_test_item.json')
+            self.assertTrue(os.path.exists(file_path))
+
+            # Check if the contents of the saved file are correct
+            with open(file_path, 'r') as f:
+                saved_item = json.load(f)
+                self.assertEqual(saved_item, item)
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory

--- a/src/collective/exportimport/tests/test_filesystem_importer.py
+++ b/src/collective/exportimport/tests/test_filesystem_importer.py
@@ -1,0 +1,182 @@
+import unittest
+import os
+import json
+import shutil
+from collective.exportimport.filesystem_importer import (
+    FileSystemContentImporter
+)
+from collective.exportimport.testing import COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+try:
+    from plone.testing import zope
+
+    OLD_ZOPE_TESTBROWSER = False
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    OLD_ZOPE_TESTBROWSER = True
+
+
+def write(self, data):
+    """Override for HTTPResponse.write.
+
+    In Zope 2 (Plone 4.3-5.1) in tests, when we export content to download it,
+    the resulting browser.contents is empty, instead of containing json.
+    This is an ugly hack to capture the data that should be available.
+    I tried a few other ways, but failed.
+    """
+    self._orig_write(data)
+    DATA.append(data)
+
+
+class TestFileSystemContentImporter(unittest.TestCase):
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set up a temporary directory for testing
+        self.temp_dir = 'temp_test_directory'
+        os.makedirs(self.temp_dir)
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_get_parents(self):
+        portal = self.layer["portal"]
+        importer = FileSystemContentImporter(portal, self.temp_dir)
+
+        # Test with a parent dictionary
+        parent = {"@id": "/test/parent/item"}
+        parent_path = importer.get_parents(parent)
+        self.assertEqual(parent_path, "test/parent/item")
+
+        # Test with no parent dictionary
+        parent_path = importer.get_parents(None)
+        self.assertEqual(parent_path, "")
+
+    def test_delete_old_if_moved(self):
+        portal = self.layer["portal"]
+        importer = FileSystemContentImporter(portal, self.temp_dir)
+        UID = "test_uid"
+
+        # Create a JSON file for an item with the test UID
+        item = {"UID": UID}
+        json_file_path = os.path.join(
+            self.temp_dir,
+            'removed_items',
+            '1_test_item.json'
+        )
+        os.makedirs(os.path.join(
+                self.temp_dir,
+                'removed_items'
+            )
+        )
+        with open(json_file_path, "w") as f:
+            json.dump(item, f, sort_keys=True, indent=4)
+
+        # Check if the file exists
+        self.assertTrue(os.path.exists(json_file_path))
+
+        # Call the method to delete the old object
+        importer.delete_old_if_moved(UID)
+
+    def test_process_deleted(self):
+        portal = self.layer["portal"]
+        importer = FileSystemContentImporter(portal, self.temp_dir)
+
+        # Create a JSON file for a deleted item
+        data = """{
+    "@id": "http://localhost:8080/Plone/intranet",
+    "@type": "Document",
+    "UID": "32eb39c7b2aa422f98d7dc7245fdf1f7",
+    "allow_discussion": false,
+    "blocks": {
+        "51b461f2-fd67-42c4-9f14-fa27dc033d38": {
+            "@type": "title"
+        },
+        "5eb1ec97-42a9-4d6b-b1f3-942359b1048c": {
+            "@type": "slate"
+        }
+    },
+    "blocks_layout": {
+        "items": [
+            "51b461f2-fd67-42c4-9f14-fa27dc033d38",
+            "5eb1ec97-42a9-4d6b-b1f3-942359b1048c"
+        ]
+    },
+    "contributors": [],
+    "created": "2023-10-03T14:31:19+00:00",
+    "creators": [
+        "admin"
+    ],
+    "description": "",
+    "effective": null,
+    "exclude_from_nav": false,
+    "expires": null,
+    "id": "intranet",
+    "is_folderish": true,
+    "language": "es",
+    "layout": "document_view",
+    "lock": {
+        "locked": false,
+        "stealable": true
+    },
+    "modified": "2023-10-03T14:31:19+00:00",
+    "parent": {
+        "@id": "http://localhost:8080/Plone",
+        "@type": "Plone Site",
+        "UID": "88f83b6e449a4cc6a4b688e17fbb4421",
+        "description": "",
+        "title": "Sitio",
+        "type_title": "Sitio Plone"
+    },
+    "preview_caption": null,
+    "preview_image": null,
+    "review_state": "private",
+    "rights": "",
+    "subjects": [],
+    "title": "Intranet",
+    "type_title": "P\u00e1gina",
+    "version": "current",
+    "workflow_history": {
+        "simple_publication_workflow": [
+            {
+                "action": null,
+                "actor": "admin",
+                "comments": "",
+                "review_state": "private",
+                "time": "2023-10-03T14:31:19+00:00"
+            }
+        ]
+    },
+    "working_copy": null,
+    "working_copy_of": null
+}
+"""
+
+        item = json.loads(data)
+        json_file_path = os.path.join(
+            self.temp_dir,
+            'removed_items',
+            '1_deleted_item.json'
+        )
+        os.makedirs(os.path.join(
+                self.temp_dir,
+                'removed_items'
+            )
+        )
+
+        with open(json_file_path, "w") as f:
+            json.dump(item, f, sort_keys=True, indent=4)
+
+        # Check if the file exists
+        self.assertTrue(os.path.exists(json_file_path))
+
+        # Call the method to process deleted items
+        message = importer.process_deleted()
+
+        # Check if the file was removed
+        self.assertTrue("Deleted 0 items" in message)

--- a/src/collective/exportimport/tests/test_import_hierarchical.py
+++ b/src/collective/exportimport/tests/test_import_hierarchical.py
@@ -1,0 +1,953 @@
+# -*- coding: utf-8 -*-
+from App.config import getConfiguration
+from collective.exportimport import config
+from collective.exportimport.testing import (
+    COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING,  # noqa: E501,
+)
+from plone import api
+from plone.app.testing import login
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.namedfile.file import NamedImage
+from Products.CMFPlone.tests import dummy
+
+import json
+import os
+import shutil
+import six
+import tempfile
+import transaction
+import unittest
+
+if six.PY2:
+    from pathlib2 import Path
+else:
+    from pathlib import Path
+
+
+try:
+    from plone.testing import zope
+
+    OLD_ZOPE_TESTBROWSER = False
+except ImportError:
+    # BBB for plone.testing 4
+    from plone.testing import z2 as zope
+    from ZPublisher.HTTPResponse import HTTPResponse
+
+    OLD_ZOPE_TESTBROWSER = True
+
+
+DATA = []
+
+
+def write(self, data):
+    """Override for HTTPResponse.write.
+
+    In Zope 2 (Plone 4.3-5.1) in tests, when we export content to download it,
+    the resulting browser.contents is empty, instead of containing json.
+    This is an ugly hack to capture the data that should be available.
+    I tried a few other ways, but failed.
+    """
+    self._orig_write(data)
+    DATA.append(data)
+
+
+class TestHierarchicalImport(unittest.TestCase):
+    """Test that we can export."""
+
+    layer = COLLECTIVE_EXPORTIMPORT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set a client home for our import directory.
+        # Usually this is buildout-dir/var/instance.
+        # In tests it is somewhere in an egg, which is not helpful.
+        cfg = getConfiguration()
+        self.orig_clienthome = cfg.clienthome
+        self.new_clienthome = tempfile.mkdtemp(suffix=".clienthome")
+        os.mkdir(os.path.join(self.new_clienthome, "import"))
+        cfg.clienthome = self.new_clienthome
+        if OLD_ZOPE_TESTBROWSER:
+            # patch HTTPResponse so we can get an attachment
+            HTTPResponse._orig_write = HTTPResponse.write
+            HTTPResponse.write = write
+
+    def tearDown(self):
+        cfg = getConfiguration()
+        cfg.clienthome = self.orig_clienthome
+        shutil.rmtree(self.new_clienthome)
+        if OLD_ZOPE_TESTBROWSER:
+            # undo patch
+            HTTPResponse.write = HTTPResponse._orig_write
+
+    def create_demo_content(self):
+        """Create a portal structure which we can test against.
+        Plone (portal root)
+        |-- blog
+        |-- folder1
+        |   |-- doc1
+        |   |-- folder2_1
+        |       |-- doc3
+        |-- folder2
+        |   |-- doc2
+        |-- image
+        """
+        portal = self.layer["portal"]
+        self.link = api.content.create(
+            container=portal,
+            type="Link",
+            id="blog",
+            title=u"Blog",
+        )
+        self.folder1 = api.content.create(
+            container=portal, type="Folder", id="folder1", title="Folder 1"
+        )
+        self.doc1 = api.content.create(
+            container=self.folder1, type="Document", id="doc1", title="Document 1"
+        )
+        self.folder2 = api.content.create(
+            container=portal, type="Folder", id="folder2", title="Folder 2"
+        )
+        self.folder2_1 = api.content.create(
+            container=self.folder1, type="Folder", id="folder2-1", title="Folder 2.1"
+        )
+        self.doc2 = api.content.create(
+            container=self.folder2, type="Document", id="doc2", title="Document 2"
+        )
+        self.doc3 = api.content.create(
+            container=self.folder2_1, type="Document", id="doc3", title="Document 3"
+        )
+        self.image = api.content.create(
+            container=portal,
+            type="Image",
+            title=u"Image",
+            id="image",
+            image=NamedImage(dummy.Image(), "image/gif", u"test.gif"),
+        )
+
+    def remove_demo_content(self):
+        """remove what was create in create_demo_content
+        Plone (portal root)
+        |-- image
+        |-- blog
+        |-- about
+        |   |-- team
+        |   `-- contact
+        `-- events
+
+        """
+        portal = self.layer["portal"]
+        api.content.delete(portal["blog"])
+        api.content.delete(portal["folder1"])
+        api.content.delete(portal["folder2"])
+        api.content.delete(portal["image"])
+
+    def open_page(self, page):
+        """Create a testbrowser, open a page, return the browser."""
+        browser = zope.Browser(self.layer["app"])
+        browser.handleErrors = False
+        browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        url = "/".join([self.layer["portal"].absolute_url(), page])
+        browser.open(url)
+        return browser
+
+    def test_import_content_page(self):
+        """Tests the import page"""
+        # Simply test that some text is on the page.
+        browser = self.open_page("@@import_content")
+        # Let's compare lowercase.
+        lower_contents = browser.contents.lower()
+        self.assertIn("import content", lower_contents)
+        self.assertIn(
+            "or you can choose from a tree export in the server in one of these paths:",
+            lower_contents
+        )
+
+    def test_import_content_from_server_tree(self):
+        """Tests a complete import"""
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Remove all content
+            self.remove_demo_content()
+            transaction.commit()
+
+            self.assertNotIn("doc1", portal.contentIds())
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back.
+            self.assertIn("doc1", portal["folder1"].contentIds())
+            new_doc = portal["folder1"]
+            self.assertEqual(new_doc.Title(), "Folder 1")
+            self.assertEqual(new_doc.portal_type, "Folder")
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_import_update_from_server_tree(self):
+        """Tests a complete import with update"""
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Remove all content
+            self.remove_demo_content()
+            transaction.commit()
+
+            self.assertNotIn("doc1", portal.contentIds())
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back.
+            self.assertIn("doc1", portal["folder1"].contentIds())
+            self.assertEqual(portal["folder1"].Title(), "Folder 1")
+            folder_uid = portal["folder1"].UID()
+            # Change exported file and upload again.
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "2_folder1.json"
+                )
+            with open(file_path, "r+") as f:
+                data = json.load(f)
+                data["title"] = "Folder 1. Updated."
+                f.seek(0)
+                json.dump(data, f, sort_keys=True, indent=4)
+                f.truncate()  # if file content was larger
+
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+            self.assertIn("folder1", portal.contentIds())
+            new_folder = portal["folder1"]
+            self.assertEqual(new_folder.Title(), "Folder 1. Updated.")
+            self.assertEqual(new_folder.UID(), folder_uid)
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_import_replace_from_server_tree(self):
+        """Tests a complete import with replace
+
+        A Connection closed error is raised if Plone Site is in the
+        export and the replace option is selected.
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Remove all content
+            self.remove_demo_content()
+            transaction.commit()
+
+            self.assertNotIn("doc1", portal.contentIds())
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back.
+            self.assertIn("doc1", portal["folder1"].contentIds())
+            self.assertEqual(portal["folder1"].Title(), "Folder 1")
+            folder_uid = portal["folder1"].UID()
+
+            # Change exported file and upload again.
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "2_folder1.json"
+                )
+            with open(file_path, "r+") as f:
+                data = json.load(f)
+                data["title"] = "Folder 1. Updated."
+                f.seek(0)
+                json.dump(data, f, sort_keys=True, indent=4)
+                f.truncate()  # if file content was larger
+
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["1"]  # replace!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+            self.assertIn("folder1", portal.contentIds())
+            new_folder = portal["folder1"]
+            self.assertEqual(new_folder.Title(), "Folder 1. Updated.")
+            self.assertEqual(new_folder.UID(), folder_uid)
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_fresh_import_moved_non_folderish_item(self):
+        """Hierarchical import allows to move content across
+        the directory structure.
+        Moved item should be created in the actual path where the
+        json file is placed.
+
+        From Plone 6+, many content types become folderish so during
+        export process a json file and a subdirectory are created for
+        each folderish item.
+
+        For non-folderish items just a json file is created.
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Remove all content
+            self.remove_demo_content()
+            transaction.commit()
+
+            self.assertNotIn("image", portal.contentIds())
+
+            # Move 2_image.json inside a subfolder
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "8_image.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "8_image.json"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertNotIn("image", portal.contentIds())
+            self.assertIn("image", portal["folder2"].contentIds())
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_fresh_import_moved_folderish_item(self):
+        """Hierarchical import allows to move content across
+        the directory structure.
+        Moved item should be created in the actual path where the
+        json file is placed.
+
+        From Plone 6+, many content types become folderish so during
+        export process a json file and a subdirectory are created for
+        each folderish item.
+
+        For non-folderish items just a json file is created.
+
+        Here we will test how to move a folderish item inside other
+        If only json file is moved, the contentish object will be 
+        created into the target location but his children will remain
+        in the same path.
+        Both json file and subfolder must be moved in order to move
+        all content to target location.
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Remove all content
+            self.remove_demo_content()
+            transaction.commit()
+
+            self.assertNotIn("image", portal.contentIds())
+
+            # Move 2_image.json inside a subfolder
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "2_folder1.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "2_folder1.json"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertIn("folder1", portal["folder2"].contentIds())
+
+            # As subfolder wasn't moved, a folder1 has been also created
+            # at his original place.
+            self.assertNotIn("folder1", portal.contentIds())
+            self.assertIn("doc1", portal["folder2"]["folder1"].contentIds())
+
+            # Move now folder1 subdir into folder2
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder1"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "folder1"
+                )
+            shutil.move(file_path, target_path)
+
+            # Remove all content
+            api.content.delete(portal["blog"])
+            api.content.delete(portal["folder2"])
+            api.content.delete(portal["image"])
+            transaction.commit()
+
+            # Now re-import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertIn("folder1", portal["folder2"].contentIds())
+            # Now, children should be created under folder2
+            self.assertNotIn("folder1", portal.contentIds())
+            self.assertIn("doc1", portal["folder2"]["folder1"].contentIds())
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+
+    def test_update_import_moved_non_folderish_item(self):
+        """Hierarchical import allows to move content across
+        the directory structure.
+        Moved item should be created in the actual path where the
+        json file is placed.
+
+        From Plone 6+, many content types become folderish so during
+        export process a json file and a subdirectory are created for
+        each folderish item.
+
+        For non-folderish items just a json file is created.
+
+        Testing moving items without deleting previous content
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Move 2_image.json inside a subfolder
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "8_image.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "8_image.json"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertNotIn("image", portal.contentIds())
+            self.assertIn("image", portal["folder2"].contentIds())
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_update_import_moved_folderish_item(self):
+        """Hierarchical import allows to move content across
+        the directory structure.
+        Moved item should be created in the actual path where the
+        json file is placed.
+
+        From Plone 6+, many content types become folderish so during
+        export process a json file and a subdirectory are created for
+        each folderish item.
+
+        For non-folderish items just a json file is created.
+
+        Here we will test how to move a folderish item inside other
+        If only json file is moved, the contentish object will be 
+        created into the target location but his children will remain
+        in the same path.
+        Both json file and subfolder must be moved in order to move
+        all content to target location.
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Move 2_image.json inside a subfolder
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "2_folder1.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "2_folder1.json"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertIn("folder1", portal["folder2"].contentIds())
+
+            # As subfolder wasn't moved, a folder1 has been also created
+            # at his original place.
+            self.assertNotIn("folder1", portal.contentIds())
+            self.assertIn("doc1", portal["folder2"]["folder1"].contentIds())
+
+            # Move now folder1 subdir into folder2
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder1"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "folder2",
+                    "folder1"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now re-import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertIn("folder1", portal["folder2"].contentIds())
+            # Now, children should be created under folder2
+            self.assertNotIn("folder1", portal.contentIds())
+            self.assertIn("doc1", portal["folder2"]["folder1"].contentIds())
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory
+
+    def test_delete_items(self):
+        """Hierarchical also allows to remove elements from site
+        without losing the json file. Just move it to the 
+        removed_items directory and the item will be deleted in portal.
+        """
+        # First create some content.
+        app = self.layer["app"]
+        portal = self.layer["portal"]
+        login(app, SITE_OWNER_NAME)
+        self.create_demo_content()
+        transaction.commit()
+
+        # Now export it to a file on the server.
+        browser = self.open_page("@@export_content")
+        browser.getControl(name="portal_type").value = [
+            "Folder",
+            "Document",
+            "Link",
+            "Image"]
+        browser.getControl(
+            "Generate a file for each item (as filesytem tree)").selected = True
+        original_central_directory = config.CENTRAL_DIRECTORY
+        try:
+            config.CENTRAL_DIRECTORY = tempfile.mkdtemp()
+            browser.getForm(action="@@export_content").submit()
+
+            msg = "Exported 8 items (Folder, Image, Link, Document) as tree to {}/exported_tree/{}/content".format(
+                config.CENTRAL_DIRECTORY,
+                portal.getId()
+            )
+            self.assertIn(msg, browser.contents)
+
+            # Move 2_image.json inside a subfolder
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "1_blog.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "removed_items",
+                    "1_blog.json"
+                )
+            shutil.move(file_path, target_path)
+
+            # Now import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 7 items", browser.contents)
+            self.assertIn("Deleted 1 items", browser.contents)
+
+            # As subfolder wasn't moved, a folder1 has been also created
+            # at his original place.
+            self.assertNotIn("blog", portal.contentIds())
+
+            # Restore content
+            file_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "removed_items",
+                    "1_blog.json"
+                )
+            target_path = os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content",
+                    "1_blog.json",
+                )
+            shutil.move(file_path, target_path)
+
+            # Now re-import it.
+            browser = self.open_page("@@import_content")
+            server_file = browser.getControl(name="server_tree_file")
+            server_file.value = [
+                os.path.join(
+                    config.CENTRAL_DIRECTORY,
+                    "exported_tree",
+                    portal.getId(),
+                    "content"
+                )
+            ]
+            browser.getControl(name="handle_existing_content").value = ["2"]  # update!
+            browser.getForm(action="@@import_content").submit()
+            self.assertIn("Imported 8 items", browser.contents)
+
+            # Content should be back to the new location
+            self.assertIn("blog", portal.contentIds())
+
+        finally:
+            shutil.rmtree(config.CENTRAL_DIRECTORY)
+            config.CENTRAL_DIRECTORY = original_central_directory


### PR DESCRIPTION


- Adds hierarchycal content export/import. A folder structure will be created and a json file per item.
  This will allow to keep track of changes for each item. Also allow to move o delete content.

- Some fixes for spanish translations

- Modifies import_content and export_content templates to include boostrap classes and change checkboxes to switches.

### Export Content
A new checkbox has been added to allow hierarchical export to server. Will generate a tree export with one json per item. For folders content a subdirectory will be added containing children.
Added bootstrap css classes and redesigned checkbox into switches.

The generated exported tree will contain a subdirectory for the exported site with two main directories: `content` and `removed_items`

exported_tree/
└── Plone
    ├── content
    │  ├── 11_registration.json
    │  ├── 12_schedule.json
    │  ├── 19_sprint.json
    │  ├── 1_contact.json
    │  ├── 20_test1.json
    │  ├── 2_events.json
    │  ├── 6_intranet.json
    │  ├── 7_location-1.json
    │  ├── 8_news.json
    │  ├── contact
    │  ├── events
    │  │       ├── 3_deadline-for-talk-submission.json
    │  │       ├── 5_second-event-in-events-folder.json
    │  │       ├── deadline-for-talk-submission
    │  │       │   └── 4_00b2dcca-4e95-4feb-bf83-3789000a017f_1_105_c.jpeg.json
    │  │       └── second-event-in-events-folder
    │  ├── intranet
    │  │   ├── 13_sponsors.json
    │  │   ├── sponsors
    │  │   ├── 15_training.json
    │  │   ├── training
    │  │   ├── 16_00b2dcca-4e95-4feb-bf83-3789000a017f_1_105_c.jpeg.json
    │  │   ├── 17_document-third-level-inside-training.json
    │  │   └── document-third-level-inside-training
    │  │       └── 18_00b2dcca-4e95-4feb-bf83-3789000a017f_1_105_c.jpeg.json
    │  ├── location-1
    │  ├── news
    │  │   ├── 10_submit-your-talks.json
    │  │   ├── 9_conference-website-online.json
    │  │   ├── conference-website-online
    │  │   └── submit-your-talks
    │  ├── registration
    │  ├── schedule
    │  ├── sprint
    │  └── test1
    └── removed_items
        └── 14_00b2dcca-4e95-4feb-bf83-3789000a017f_1_105_c.jpeg.json

### Import Content
Redesigned form with bootstrap css classes, added fieldsets to separate type of imports.
A new fieldset added for the hierarchical import where you can select the server path to the `exported_tree`

### Moving content
Non folderish item can be moved by just changing the location of the json file.
Folderish object can be moved by changing the location of both json file and subdirectory.

### Reordering
Exported json files names include the ordinal number of the original order. At the moment, no further reordering system has been implemented.

### Marking content as deleted
Moving json files to `removed_items`will mark them as deleted. In an update import, where site has content, that item will be removed.
**Disclaimer: this will be remove the item without taking care of link integrity**
