### PR TITLE
ATTopic export_content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
   This fixes an error at the end of the export and no errors being written.
   [thet]
 
+- Add support for ATTopic export_content
+  [avoinea]
+
 
 1.10 (2023-10-11)
 -----------------

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -20,6 +20,15 @@
       />
 
   <browser:page
+      zcml:condition="installed Products.ATContentTypes.content.topic"
+      name="export_content"
+      for="Products.ATContentTypes.interfaces.IATTopic"
+      class=".export_topic.ExportTopic"
+      template="templates/export_content.pt"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:page
       name="export_relations"
       for="zope.interface.Interface"
       class=".export_other.ExportRelations"

--- a/src/collective/exportimport/export_topic.py
+++ b/src/collective/exportimport/export_topic.py
@@ -1,0 +1,9 @@
+""" Export ATTopic """
+from collective.exportimport.export_content import ExportContent
+
+
+class ExportTopic(ExportContent):
+    """ Export ATTopic """
+    def build_query(self):
+        """ Build the query based on the topic criterias """
+        return self.context.buildQuery()


### PR DESCRIPTION
Sometimes you want to export a collection of items from an old Plone4 website and import them all in one folder. This way you can add a ATTopic with a custom query and then call `my-topic/export_content`.