### PR TITLE
Allow to use fix_html_in_content_fields without applying the default html_fixer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.11 (unreleased)
 -----------------
 
+- Allow to use fix_html_in_content_fields without applying the default html_fixer.
+  [pbauer]
+
 - Try to restore broken blobs when exporting content.
   [thet]
 

--- a/src/collective/exportimport/fix_html.py
+++ b/src/collective/exportimport/fix_html.py
@@ -247,7 +247,9 @@ def find_object(base, path):
         return target
 
 
-def fix_html_in_content_fields(context=None, commit=True, fixers=None):
+def fix_html_in_content_fields(
+    context=None, commit=True, fixers=None, apply_default_fixer=True
+):
     """Fix html this after importing content into Plone 5 or 6.
     When calling this from your code you can pass additional fixers to modify the html.
 
@@ -296,7 +298,9 @@ def fix_html_in_content_fields(context=None, commit=True, fixers=None):
     else:
         if not isinstance(fixers, list):
             fixers = [fixers]
-        fixers = [html_fixer] + [i for i in fixers if callable(i)]
+        fixers = [i for i in fixers if callable(i)]
+        if apply_default_fixer:
+            fixers.prepend(html_fixer)
 
     try:
         # Add img_variant_fixer if we are running this in Plone 6.x


### PR DESCRIPTION
This way you can use it in upgrade-steps
e.g:
```python
def upgrade(setup_tool=None):
    from collective.exportimport.fix_html import fix_html_in_content_fields

    fixers = [text_img_align_fixer]
    fix_html_in_content_fields(fixers=fixers, apply_default_fixer=False)


def text_img_align_fixer(text, obj=None):
    """Replace inline-styles for img tags with classes."""
    from bs4 import BeautifulSoup

    if not text:
        return text

    replaced_styles = {
        "float: left": "image-left",
        "float: right": "image-right",
    }
    soup = BeautifulSoup(text, "html.parser")
    for tag in soup.find_all("img"):
        styles = tag.get("style", "").split(";")
        styles = [i.strip() for i in styles if i.strip()]
        if not styles:
            continue

        new_classes = []
        old_classes = tag.get("class", [])

        for old, new in replaced_styles.items():
            if old in styles:
                styles.remove(old)
                new_classes.append(new)
                if "image-inline" in old_classes:
                    old_classes.remove("image-inline")

        if new_classes:
            tag["class"] = old_classes + new_classes

        if styles:
            tag["style"] = ";".join(styles)
        else:
            del tag["style"]
    return soup.decode()
```