### PR TITLE
Fix `KeyError: time` on import with workflow without `time` variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.11 (unreleased)
 -----------------
 
+- Fix ``KeyError: time`` when importing content with a workflow that does not have the ``time`` variable.
+  [maurits]
+
 - Allow to use fix_html_in_content_fields without applying the default html_fixer.
   [pbauer]
 

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -816,9 +816,10 @@ class ImportContent(BrowserView):
         for key, value in workflow_history.items():
             # The time needs to be deserialized
             for history_item in value:
-                history_item["time"] = DateTime(
-                    dateutil.parser.parse(history_item["time"])
-                )
+                if "time" in history_item:
+                    history_item["time"] = DateTime(
+                        dateutil.parser.parse(history_item["time"])
+                    )
             result[key] = value
         if result:
             obj.workflow_history = PersistentMapping(result.items())


### PR DESCRIPTION
Fixes https://github.com/collective/collective.exportimport/issues/222