### PR TITLE
Better Plone 4 / Python 2 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.11 (unreleased)
 -----------------
 
+- Add more Python 2 compatible version specifications and update the README.
+  [thet]
+
 - Fix ``KeyError: time`` when importing content with a workflow that does not have the ``time`` variable.
   [maurits]
 

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,28 @@ Import supports:
 
 * Plone 5.2+, Dexterity, Python 2 and 3, plone.app.multilingual
 
+
+Installation
+============
+
+Install collective.exportimport as you would install any other Python package.
+
+You don't need to activate the add-on in the Site Setup Add-ons control panel to be able to use the forms ``@@export_content`` and ``@@import_content`` in your site.
+
+If you need help, see:
+- for Plone 4: https://4.docs.plone.org/adapt-and-extend/install_add_ons.html
+- for Plone 5: https://5.docs.plone.org/manage/installing/installing_addons.html
+- for Plone 6: https://6.docs.plone.org/install/manage-add-ons-packages.html
+
+
+Python 2 compatibility
+----------------------
+
+This package is compatible with Python 3 and Python 2.
+Depending on the Python version different versions of it's dependencies will be installed.
+If you run into problems, file an issue at: https://github.com/collective/collective.exportimport/issues
+
+
 Usage
 =====
 
@@ -2152,68 +2174,6 @@ Translations
 This product has been translated into
 
 - Spanish
-
-
-Installation
-============
-
-Install collective.exportimport by adding it to your buildout::
-
-    [buildout]
-
-    ...
-
-    eggs =
-        collective.exportimport
-
-
-and then running ``bin/buildout``
-
-You don't need to activate the add-on in the Site Setup Add-ons control panel to be able to use the forms ``@@export_content`` and ``@@import_content`` in your site.
-
-You do need to add it to your buildout configuration and run buildout to make these features available at all. See https://docs.plone.org/manage/installing/installing_addons.html for details.
-
-Installing in Plone 4
----------------------
-
-``collective.exportimport`` depends on ``plone.restapi``. For Plone 4, you need to pin ``plone.restapi`` to 7.x . When installing ``plone.restapi`` version 7.x.x in Plone 4 you may need to add the following version pins to your buildout::
-
-    [versions]
-    PyJWT = 1.7.1
-
-    six = 1.11.0
-    attrs = 21.2.0
-    plone.rest = 1.6.2
-    plone.schema = 1.3.0
-    # Last pyrsistent version that is python 2 compatible:
-    pyrsistent = 0.15.7
-
-    # Required by:
-    # jsonschema==3.2.0
-    functools32 = 3.2.3.post2
-
-    # Required by:
-    # plone.schema==1.3.0
-    jsonschema = 3.2.0
-
-    # Required by:
-    # importlib-metadata==1.3.0
-    pathlib2 = 2.3.5
-
-    # Required by:
-    # pathlib2==2.3.5
-    scandir = 1.10.0
-
-    # plone.app.contenttypes > 1.0
-    plone.app.contenttypes = 1.1.9
-
-    importlib-metadata = 2.1.3
-    zipp = 1.2.0
-    configparser = 4.0.2
-    contextlib2 = 0.6.0.post1
-
-
-These versions are taken from the ``plone.restapi`` 7.x README: https://pypi.org/project/plone.restapi/7.8.1/
 
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -2146,14 +2146,6 @@ This ``global_obj_hook`` below stores that data in a annotation:
             annotations[DEFERRED_KEY] = data
 
 
-Written by
-==========
-
-.. image:: ./docs/starzel.png
-    :target: https://www.starzel.de
-    :alt: Starzel.de
-
-
 Translations
 ============
 
@@ -2241,3 +2233,11 @@ License
 -------
 
 The project is licensed under the GPLv2.
+
+
+Written by
+==========
+
+.. image:: ./docs/starzel.png
+    :target: https://www.starzel.de
+    :alt: Starzel.de

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
 
 if sys.version_info[0] < 3:
     install_requires.append("attrs < 22")
+    install_requires.append("backports.functools-lru-cache < 2")
     install_requires.append("beautifulsoup4 < 4.10")
     # plone.restapi depends on plone.schema, which depends on jsonschema,
     # which has a Py3-only release since September 2021.

--- a/setup.py
+++ b/setup.py
@@ -18,23 +18,27 @@ long_description = "\n\n".join(
 install_requires = [
     "hurry.filesize",
     "ijson",
-    "plone.api >= 1.8.4",
     "setuptools",
     "six",
 ]
 
 if sys.version_info[0] < 3:
+    install_requires.append("attrs < 22")
     install_requires.append("beautifulsoup4 < 4.10")
     # plone.restapi depends on plone.schema, which depends on jsonschema,
     # which has a Py3-only release since September 2021.
     install_requires.append("jsonschema < 4")
     install_requires.append("pathlib2")
+    install_requires.append("plone.api >= 1.8.4, < 2")
     # There is a py2-imcompatibility in plone.rest 3.0.1
     install_requires.append("plone.rest < 3.0.1")
-    install_requires.append("plone.restapi < 8.0.0")
+    install_requires.append("plone.restapi < 8")
+    install_requires.append("plone.schema < 2")
+    install_requires.append("PyJWT < 2")
     install_requires.append("pyrsistent < 0.16.0")
 else:
     install_requires.append("beautifulsoup4")
+    install_requires.append("plone.api >= 1.8.4")
     install_requires.append("plone.restapi")
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,26 +16,26 @@ long_description = "\n\n".join(
 )
 
 install_requires = [
-    "setuptools",
-    "plone.api >= 1.8.4",
     "hurry.filesize",
     "ijson",
+    "plone.api >= 1.8.4",
+    "setuptools",
     "six",
 ]
 
 if sys.version_info[0] < 3:
     install_requires.append("beautifulsoup4 < 4.10")
-    install_requires.append("plone.restapi < 8.0.0")
-    # There is a py2-imcompatibility in plone.rest 3.0.1
-    install_requires.append("plone.rest < 3.0.1")
     # plone.restapi depends on plone.schema, which depends on jsonschema,
     # which has a Py3-only release since September 2021.
     install_requires.append("jsonschema < 4")
-    install_requires.append("pyrsistent < 0.16.0")
     install_requires.append("pathlib2")
+    # There is a py2-imcompatibility in plone.rest 3.0.1
+    install_requires.append("plone.rest < 3.0.1")
+    install_requires.append("plone.restapi < 8.0.0")
+    install_requires.append("pyrsistent < 0.16.0")
 else:
-    install_requires.append("plone.restapi")
     install_requires.append("beautifulsoup4")
+    install_requires.append("plone.restapi")
 
 
 setup(


### PR DESCRIPTION
When I‌ tried to install this package in Plone 4 it took me some time to get the versions straight. It would have saved me some time if I had read the Plone 4 install section in the README, but I didn't and it is well hidden.

I think having an easy installation experience in Plone 4 with Python 2 is quite important for this package as this is probably a frequent use case.

This PR should fix that out of the box and improve the README a bit, as of the time of this writing. There is a good chance that it will break again, however, for now it does work fine.

/cc @canepan