### PR TITLE
safeguard against empty/None values in default_page_uuid

### DIFF
--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -535,7 +535,7 @@ class ImportDefaultPages(BrowserView):
                     obj = api.portal.get()
                 else:
                     continue
-            if "default_page_uuid" in item:
+            if "default_page_uuid" in item and item.get("default_page_uuid", None):
                 default_page_obj = api.content.get(UID=item["default_page_uuid"])
                 if not default_page_obj:
                     logger.info("Default page missing: %s", item["default_page_uuid"])


### PR DESCRIPTION
We have seen values like this when doing an export of a Plone 4 site:

```json
{
        "default_page": "index_html", 
        "default_page_uuid": null, 
        "uuid": "418cd0dd43d7433c9e508679c649a9ff"
    }, 
    {
        "default_page": "index_html", 
        "default_page_uuid": null, 
        "uuid": "19c24adf7cae434c897285fab5cbf240"
    }, 
```

These changes check whether the value in `default_page_uuid` is not None, before searching the item in the catalog.
