### PR TITLE
Fix AtributeError 'NamedFile' object has no attribute '_blob' when exporting objects with plone.namedfile.file.NamedFile properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.11 (unreleased)
 -----------------
 
+- Fix ``AtributeError: 'NamedFile' object has no attribute '_blob'`` when using setting
+  "Include blobs as blob paths" and exporting objects with
+  plone.namedfile.file.NamedFile properties (so not blobs).
+  [valipod]
+
 - Fix ``KeyError: time`` when importing content with a workflow that does not have the ``time`` variable.
   [maurits]
 

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -130,6 +130,7 @@
   <!-- Serializers -->
   <adapter factory=".serializer.FileFieldSerializerWithBlobs" />
   <adapter factory=".serializer.FileFieldSerializerWithBlobPaths" />
+  <adapter factory=".serializer.FileFieldSerializerZODBData" />
   <adapter factory=".serializer.ImageFieldSerializerWithBlobs" />
   <adapter factory=".serializer.ImageFieldSerializerWithBlobPaths" />
   <adapter factory=".serializer.RichttextFieldSerializerWithRawText" />

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -7,7 +7,7 @@ from collective.exportimport.interfaces import ITalesField
 from hurry.filesize import size
 from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityContent
-from plone.namedfile.interfaces import INamedFileField
+from plone.namedfile.interfaces import INamedFileField, INamedBlobFileField
 from plone.namedfile.interfaces import INamedImageField
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import IJsonCompatible
@@ -548,6 +548,15 @@ def get_dx_blob_path(obj):
 
 
 @adapter(INamedFileField, IDexterityContent, IPathBlobsMarker)
+@implementer(IFieldSerializer)
+class FileFieldSerializerZODBData(FileFieldSerializerWithBlobs):
+    """ Although the marker is IPathBlobsMarker, this being a plain NamedFile
+    object, its data is in the ZODB, thus this still needs to be
+    base64 encoded into the JSON file
+    So we just subclass from the above FileFieldSerializerWithBlobs """
+
+
+@adapter(INamedBlobFileField, IDexterityContent, IPathBlobsMarker)
 @implementer(IFieldSerializer)
 class FileFieldSerializerWithBlobPaths(DefaultFieldSerializer):
     def __call__(self):


### PR DESCRIPTION
Fixes #147

Use more specific interface INamedBlobFileField for blob files and leave INamedFileField to be base64 encoded even with blob_paths selected