### PR TITLE
Ignore transitive membership of groups 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Changelog
 - Add principals to groups that already exist during import (#228)
   [pbauer]
 
+- In export_members ignore transitive membership of groups (#240)
+  [pbauer]
+
+
 1.10 (2023-10-11)
 -----------------
 

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -300,8 +300,14 @@ class ExportMembers(BaseExport):
 
     def _getUserData(self, userId):
         member = self.pms.getMemberById(userId)
-        groups = member.getGroups()
-        groups = [i for i in groups if i not in self.AUTO_GROUPS]
+        groups = []
+        group_ids = [i for i in member.getGroups() if i not in self.AUTO_GROUPS]
+        # Drop groups in which the user is a transitive member
+        for group_id in group_ids:
+            group = api.group.get(group_id)
+            plone_group = group.getGroup()
+            if userId in plone_group.getMemberIds():
+                groups.append(group_id)
         group_roles = []
         for gid in groups:
             group_roles.extend(self.group_roles.get(gid, []))

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -321,10 +321,14 @@ class TestExport(unittest.TestCase):
         data = json.loads(contents)
         self.assertIn("groups", data.keys())
         self.assertIn("members", data.keys())
-        member_data = data["members"][0]
-        self.assertEqual(member_data["username"], TEST_USER_ID)
-        # Only direct membership is exported
-        self.assertEqual(member_data["groups"], ["Direct"])
+        members = data["members"]
+        membernames = [member["username"] for member in members]
+        self.assertIn(TEST_USER_ID, membernames)
+        for member in members:
+            if member["username"] == TEST_USER_ID:
+                self.assertEqual(member["username"], TEST_USER_ID)
+                # Only direct membership is exported
+                self.assertEqual(member["groups"], ["Direct"])
 
     def test_export_defaultpages_empty(self):
         browser = self.open_page("@@export_defaultpages")

--- a/src/collective/exportimport/tests/test_export.py
+++ b/src/collective/exportimport/tests/test_export.py
@@ -305,6 +305,27 @@ class TestExport(unittest.TestCase):
             if member["username"] == TEST_USER_ID:
                 self.assertTrue(member["roles"], ["Member"])
 
+    def test_export_indirect_members(self):
+        direct = api.group.create("Direct")
+        indirect = api.group.create("Indirect")
+        api.group.add_user(group=direct, username=TEST_USER_ID)
+        # Make user a indirect member of the group indirect
+        api.group.add_user(group=direct, user=indirect)
+
+        transaction.commit()
+        browser = self.open_page("@@export_members")
+        browser.getForm(action="@@export_members").submit(name="form.submitted")
+        contents = browser.contents
+        if not browser.contents:
+            contents = DATA[-1]
+        data = json.loads(contents)
+        self.assertIn("groups", data.keys())
+        self.assertIn("members", data.keys())
+        member_data = data["members"][0]
+        self.assertEqual(member_data["username"], TEST_USER_ID)
+        # Only direct membership is exported
+        self.assertEqual(member_data["groups"], ["Direct"])
+
     def test_export_defaultpages_empty(self):
         browser = self.open_page("@@export_defaultpages")
         browser.getForm(action="@@export_defaultpages").submit(name="form.submitted")


### PR DESCRIPTION
Ignore when a user is a member of group x only because he is in another group that is a member of x