### PR TITLE
Fix migrating bocks 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.12 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix migrating bocks to make Volto sites portable and support plone.distribution.
+  [pbauer, tlotze]
 
 
 1.11 (2024-02-28)

--- a/src/collective/exportimport/configure.zcml
+++ b/src/collective/exportimport/configure.zcml
@@ -137,10 +137,12 @@
   <adapter factory=".serializer.CollectionFieldSerializer" />
   <adapter factory=".serializer.ChoiceFieldSerializer" />
   <adapter factory=".serializer.long_converter" />
+  <adapter factory=".serializer.ExportingBlocksJSONFieldSerializer" />
 
   <!-- Deserializers -->
   <adapter factory=".deserializer.RichTextFieldDeserializerWithoutUnescape" />
   <adapter factory=".deserializer.PortletRichTextFieldDeserializer" />
+  <adapter factory=".deserializer.ImportingBlocksJSONFieldDeserializer" />
 
   <browser:page
       name="exportimport_links"

--- a/src/collective/exportimport/deserializer.py
+++ b/src/collective/exportimport/deserializer.py
@@ -3,8 +3,11 @@ from plone.app.textfield.interfaces import IRichText
 from plone.app.textfield.value import RichTextValue
 from plone.dexterity.interfaces import IDexterityContent
 from plone.portlets.interfaces import IPortletAssignment
+from plone.restapi.behaviors import IBlocks
 from plone.restapi.deserializer.dxfields import DefaultFieldDeserializer
 from plone.restapi.interfaces import IFieldDeserializer
+from plone.restapi.interfaces import IFieldDeserializer
+from plone.schema import IJSONField
 from zope.component import adapter
 from zope.interface import implementer
 
@@ -15,6 +18,7 @@ class RichTextFieldDeserializerWithoutUnescape(DefaultFieldDeserializer):
     """Override default RichTextFieldDeserializer without using html_parser.unescape().
     Fixes https://github.com/collective/collective.exportimport/issues/99
     """
+
     def __call__(self, value):
         content_type = self.field.default_mime_type
         encoding = "utf8"
@@ -38,3 +42,11 @@ class RichTextFieldDeserializerWithoutUnescape(DefaultFieldDeserializer):
 @adapter(IRichText, IPortletAssignment, IMigrationMarker)
 class PortletRichTextFieldDeserializer(RichTextFieldDeserializerWithoutUnescape):
     pass
+
+
+@implementer(IFieldDeserializer)
+@adapter(IJSONField, IBlocks, IMigrationMarker)
+class ImportingBlocksJSONFieldDeserializer(DefaultFieldDeserializer):
+    """We skip the subscribers that deserialize the blocks from the frontend.
+    We only need the raw data.
+    """

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -9,10 +9,13 @@ from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.interfaces import INamedFileField, INamedBlobFileField
 from plone.namedfile.interfaces import INamedImageField
+from plone.restapi.behaviors import IBlocks
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import IJsonCompatible
+from plone.restapi.serializer.blocks import BlocksJSONFieldSerializer
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.dxfields import DefaultFieldSerializer
+from plone.schema import IJSONField
 from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getUtility
@@ -605,6 +608,14 @@ class ImageFieldSerializerWithBlobPaths(DefaultFieldSerializer):
             "blob_path": blobfilepath,
         }
         return json_compatible(result)
+
+
+@adapter(IJSONField, IBlocks, IMigrationMarker)
+@implementer(IFieldSerializer)
+class ExportingBlocksJSONFieldSerializer(DefaultFieldSerializer):
+    """We skip the subscribers that serialize the blocks for the frontend.
+    We only need the raw data.
+    """
 
 
 if six.PY2:


### PR DESCRIPTION
bypass the frontend-specific modifiers when serializing and deserializing blocks