### PR TITLE
fix for exporting from Castle sites, found at Beethovensprint2024

### DIFF
--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -90,10 +90,12 @@ class FileFieldSerializerWithBlobs(DefaultFieldSerializer):
             return None
 
         try:
-            if "built-in function id" in namedfile.filename:
+            if namedfile.filename and "built-in function id" in namedfile.filename:
                 filename = self.context.id
             else:
                 filename = namedfile.filename
+            if not filename:
+                filename = self.context.id
         except AttributeError:
             # Try to recover broken namedfile
             # Related to: WARNING OFS.Uninstalled Could not import class 'NamedBlobFile' from module 'zope.app.file.file'


### PR DESCRIPTION
When exporting from a CastleCMS site, it turned out namedfile.filename wasn't always defined. Found and fixed by @pbauer, should be integrated in main.