### PR TITLE
Fix issue 247, migration was always true.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.13 (unreleased)
 -----------------
 
+- Make it possible to switch off changing data for migration.
+  Previous, you could uncheck this checkbox in ``export_content``, but this was ignored.
+  This fixes `issue 247 <https://github.com/collective/collective.exportimport/issues/247>`_.
+  [maurits]
+
 - Load code for exporting/importing comments conditionally.
   ``plone.app.discussion`` is optional since Plone 6.1.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.13 (unreleased)
 -----------------
 
+- Fix styling of ``export_content`` page in Plone 6.1.
+  The checkbox inputs were displayed in block instead of inline with the label.
+  [maurits]
+
 - Make it possible to switch off changing data for migration.
   Previous, you could uncheck this checkbox in ``export_content``, but this was ignored.
   This fixes `issue 247 <https://github.com/collective/collective.exportimport/issues/247>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
-zc.buildout==3.0.1
+zc.buildout==3.3
 # setuptools 67 is too strict with versions
 setuptools<67

--- a/src/collective/exportimport/export_content.py
+++ b/src/collective/exportimport/export_content.py
@@ -110,14 +110,24 @@ class ExportContent(BrowserView):
         depth=-1,
         include_blobs=1,
         download_to_server=False,
-        migration=True,
+        migration=False,
         include_revisions=False,
         write_errors=False,
     ):
         self.portal_type = portal_type or []
         if isinstance(self.portal_type, str):
             self.portal_type = [self.portal_type]
-        self.migration = migration
+
+        # Should we adapt the data for migration?
+        # We had migration=True by default at first.  Problem is that when you
+        # uncheck the migration box in the form, it does not end up in the
+        # request, so migration would still be True.  See
+        # https://github.com/collective/collective.exportimport/issues/247
+        if self.request.method == "GET":
+            # By default we want this, so on initial page load we make it true.
+            self.migration = True
+        else:
+            self.migration = migration
         self.path = path or "/".join(self.context.getPhysicalPath())
 
         self.depth = int(depth)

--- a/src/collective/exportimport/templates/export_content.pt
+++ b/src/collective/exportimport/templates/export_content.pt
@@ -5,6 +5,9 @@
       i18n:domain="collective.exportimport"
       metal:use-macro="context/main_template/macros/master">
 
+<style metal:fill-slot="style_slot">
+  label input { display: inline-block };
+</style>
 <div metal:fill-slot="main">
     <tal:main-macro metal:define-macro="main">
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     plone50-py27
     plone51-py27
     plone52-py{27,36,37,38}
-    plone60-py{38,39}
+    plone60-py{39,310,311}
 
 [testenv]
 # We do not install with pip, but with buildout:


### PR DESCRIPTION
Fixes issue #247.

Also a fix for 6.1.  The boolean checkboxes in `export_content` were displayed in block:

![Screenshot 2025-01-07 at 22 45 15](https://github.com/user-attachments/assets/a7d181c5-130f-4e0c-9e39-043bb0db38e0)

This is because some change in Barceloneta for 6.1 sets `label input {display: block}`.  I guess this is fine in general, but not here.

Now they are displayed inline again:

![Screenshot 2025-01-07 at 22 45 30](https://github.com/user-attachments/assets/c187ed0e-0609-4cf1-9f78-1a7fa7f16a86)


