### PR TITLE
Fix `AttributeError: __contains__` when checking default-page on non folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix ``AttributeError: __contains__`` when checking for default-page on no longer folderish object.
+  A custom migration may have turned a former container into an item.
+  [maurits]
 
 
 1.13 (2025-01-08)

--- a/base.cfg
+++ b/base.cfg
@@ -50,6 +50,11 @@ wheel =
 zc.buildout =
 pip =
 
+[versions:python38]
+# plone.restapi 7 fails with a pkg_resources.DistributionNotFound for this line in plone.restapi itself:
+# plone_restapi_version = pkg_resources.require("plone.restapi")[0].version
+plone.restapi = 9.13.2
+
 [versions:python27]
 # Last pyrsistent version that is python 2 compatible:
 pyrsistent = 0.15.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
-# setuptools 67 is too strict with versions
-setuptools<67
+setuptools<69.0.3

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -550,7 +550,17 @@ class ImportDefaultPages(BrowserView):
             else:
                 # fallback for old export versions
                 default_page = item["default_page"]
-            if default_page not in obj:
+            try:
+                is_child = default_page in obj
+            except AttributeError:
+                # If the  object used to be a Folder and a custom migration turned it
+                # into something non-folderish, you get: AttributeError: __contains__
+                logger.info(
+                    u"Cannot set default page because object is not folderish: %s",
+                    obj.absolute_url(),
+                )
+                continue
+            if not is_child:
                 logger.info(
                     u"Default page not a child: %s not in %s",
                     default_page,


### PR DESCRIPTION
A custom migration may have turned a former container into an item.