### PR TITLE
Try to fix CI.

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -50,6 +50,11 @@ wheel =
 zc.buildout =
 pip =
 
+[versions:python38]
+# plone.restapi 7 fails with a pkg_resources.DistributionNotFound for this line in plone.restapi itself:
+# plone_restapi_version = pkg_resources.require("plone.restapi")[0].version
+plone.restapi = 9.13.2
+
 [versions:python27]
 # Last pyrsistent version that is python 2 compatible:
 pyrsistent = 0.15.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
-setuptools<69.0.3
+setuptools
+setuptools==75.3.2; python_version == '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
-# setuptools 67 is too strict with versions
-setuptools<67
+# setuptools 67 started too strict with versions, but has a fix in 67.5.1
+setuptools==67.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
-# setuptools 67 started too strict with versions, but has a fix in 67.5.1
-setuptools==67.5.1
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
 setuptools
-setuptools==75.3.2; python_version == '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # For Buildout related packages, it is easiest to keep them at the same version for all environments.
 # Keep these in sync with base.cfg please:
 zc.buildout==3.3
-setuptools
+setuptools<69.0.3


### PR DESCRIPTION
When I manually return GitHub Actions on the main branch, it currently [fails](https://github.com/collective/collective.exportimport/actions/runs/13956151035/job/39067631154) for several Python versions. Error is for example:

```
pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '3.4dev-r73107'
(package: zope.exceptions)
```

A slightly newer setuptools should help here.  But I try not to make a big version jump.