### PR TITLE
Fix when reimporting existing translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 1.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix when re-importing translations. @petschki
 
 
 1.13 (2025-01-08)

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -175,6 +175,8 @@ if HAS_PAM:  # noqa: C901
             ITranslationManager(obj).register_translation(language, translation)
         except TypeError as e:
             logger.info(u"Item is not translatable: {}".format(e))
+        except KeyError as e:
+            logger.info(u"Item already translated: {}".format(e))
 
 else:
 


### PR DESCRIPTION
p.a.multilingual raises `KeyError` when translation is already linked 🤷🏼‍♂️

See https://github.com/plone/plone.app.multilingual/blob/master/src/plone/app/multilingual/manager.py#L85