### PR TITLE
Fix CI again, for Plone 6.0.

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -43,12 +43,12 @@ eggs = zest.releaser[recommended]
 collective.exportimport =
 hurry.filesize = 0.9
 pyjwt = 1.7.1
-# For Buildout related packages, it is easiest to keep them at the same version for all environments.
-# Keep these empty will ensure it uses what got installed by requirements.txt
+# For Buildout related packages, keeping these empty will ensure it uses what got installed by requirements.txt
 setuptools =
 wheel =
 zc.buildout =
 pip =
+packaging =
 
 [versions:python38]
 # plone.restapi 7 fails with a pkg_resources.DistributionNotFound for this line in plone.restapi itself:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-# For Buildout related packages, it is easiest to keep them at the same version for all environments.
-# Keep these in sync with base.cfg please:
-zc.buildout==3.3
-setuptools<69.0.3
+zc.buildout==3.3; python_version <= '3.8'
+setuptools<69.0.3; python_version <= '3.8'
+zc.buildout==4.1.7; python_version >= '3.9'
+setuptools==75.8.2; python_version >= '3.9'
+packaging==24.2; python_version >= '3.9'
+pip==25.0.1; python_version >= '3.9'
+wheel==0.45.1; python_version >= '3.9'


### PR DESCRIPTION
Use more recent zc.buildout and setuptools versions on Python 3.9+.

Sample [failure](https://github.com/collective/collective.exportimport/actions/runs/14313320340/job/40167791650#step:8:1178):

```
While:
  Installing test.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/runner/work/collective.exportimport/collective.exportimport/.tox/plone60-py311/lib/python3.11/site-packages/zc/buildout/buildout.py", line 2300, in main
    getattr(buildout, command)(args)
  File "/home/runner/work/collective.exportimport/collective.exportimport/.tox/plone60-py311/lib/python3.11/site-packages/zc/buildout/buildout.py", line 856, in install
    installed_files = self[part]._call(recipe.install)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/collective.exportimport/collective.exportimport/.tox/plone60-py311/lib/python3.11/site-packages/zc/buildout/buildout.py", line 1659, in _call
    return f()
           ^^^
  File "/home/runner/eggs/zc.recipe.testrunner-3.1-py3.11.egg/zc/recipe/testrunner/__init__.py", line 48, in install
    test_paths = [ws.find(pkg_resources.Requirement.parse(spec)).location
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/eggs/zc.recipe.testrunner-3.1-py3.11.egg/zc/recipe/testrunner/__init__.py", line 48, in <listcomp>
    test_paths = [ws.find(pkg_resources.Requirement.parse(spec)).location
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'location'
```

If the tests still fail after this, we may need one or both of these fixes:

* https://github.com/zopefoundation/zc.recipe.testrunner/pull/21
* https://github.com/buildout/buildout/pull/698