### PR TITLE
Fix missing relations in `export_relations` on a multilanguage site

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Fix when re-importing translations. @petschki
 
+- Fix issue in ``export_relations`` on a multilanguage site. @petschki
+
 - Fix ``AttributeError: __contains__`` when checking for default-page on no longer folderish object.
   A custom migration may have turned a former container into an item.
   [maurits]

--- a/src/collective/exportimport/export_other.py
+++ b/src/collective/exportimport/export_other.py
@@ -197,9 +197,13 @@ class ExportRelations(BaseExport):
                         continue
                     if rel_from_path_and_rel_to_path:
                         from_brain = portal_catalog(
-                            path=dict(query=rel.from_path, depth=0)
+                            path=dict(query=rel.from_path, depth=0),
+                            Language="all",
                         )
-                        to_brain = portal_catalog(path=dict(query=rel.to_path, depth=0))
+                        to_brain = portal_catalog(
+                            path=dict(query=rel.to_path, depth=0),
+                            Language="all",
+                        )
                         if len(from_brain) > 0 and len(to_brain) > 0:
                             item = {
                                 "from_uuid": from_brain[0].UID,


### PR DESCRIPTION
We investigated this issue in a Plone 4.3/dexterity multilanguage site. There were missing `relatedItems` relations on translated content items. Adding the index `Language="all"` fixed it.

I've also tried this change on a fresh 4.3 site without the `Language` index and it worked too. portal_catalog seems to ignore the keywords when there is no index.