### PR TITLE
fix: concatenate all `Pdata` chunks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 1.16 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed data extraction to concatenate all `Pdata` chunks. [@jnptk]
 
 
 1.15 (2025-07-15)

--- a/src/collective/exportimport/serializer.py
+++ b/src/collective/exportimport/serializer.py
@@ -270,11 +270,17 @@ if HAS_AT:
             file_obj = self.field.get(self.context)
             if not file_obj:
                 return None
-            data = (
-                file_obj.data.data
-                if isinstance(file_obj.data, Pdata)
-                else file_obj.data
-            )
+
+            data = None
+            if isinstance(file_obj.data, Pdata):
+                data = b""
+                pdata = file_obj.data
+                while pdata is not None:
+                    data += pdata.data
+                    pdata = pdata.next
+            else:
+                data = file_obj.data
+
             if len(data) > FILE_SIZE_WARNING:
                 logger.info(
                     u"Large file for {}: {}".format(


### PR DESCRIPTION
Fixes data extraction from `Pdata` objects by traversing the entire linked list and concatenating all chunks, rather than only reading the first node's data.