### PR TITLE
Skip setting a default page if the default is already set to the same value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 1.16 (unreleased)
 -----------------
 
+- Skip setting a default page if the default is already set to the same value. 
+  [mamico]
 - Fixed data extraction of Archetypes ATFilefields to concatenate all `Pdata` chunks, when the FileField data was still stored in Filestorage and not not migrated to use blobstorage (using plone.app.blobs).
   [@jnptk]
 

--- a/src/collective/exportimport/import_other.py
+++ b/src/collective/exportimport/import_other.py
@@ -575,8 +575,12 @@ class ImportDefaultPages(BrowserView):
                 continue
 
             if six.PY2:
+                if obj.getDefaultPage() == default_page.encode("utf-8"):
+                    continue
                 obj.setDefaultPage(default_page.encode("utf-8"))
             else:
+                if obj.getDefaultPage() == default_page:
+                    continue
                 obj.setDefaultPage(default_page)
             logger.debug(
                 u"Set %s as default page for %s", default_page, obj.absolute_url()


### PR DESCRIPTION
* Reduce the number of database writes.
* Make the report on the number of changes more accurate.