### PR TITLE
Pre-check images so failures in PIL can be tied to a specific item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 1.17 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Pre-check images so the PIL warning from plone.namedfile can be tied to a specific item.
+  [valipod]
 
 1.16 (2026-02-27)
 -----------------

--- a/src/collective/exportimport/import_content.py
+++ b/src/collective/exportimport/import_content.py
@@ -747,6 +747,21 @@ class ImportContent(BrowserView):
             # Write the field.
             with open(abs_blob_path, "rb") as myfile:
                 blobdata = myfile.read()
+            # Pre-check images so the PIL warning from plone.namedfile can be
+            # tied to a specific item.
+            if klass is NamedBlobImage:
+                try:
+                    import PIL.Image
+                    from io import BytesIO
+                    PIL.Image.open(BytesIO(blobdata)).verify()
+                except Exception as exc:
+                    logger.warning(
+                        "Broken or unsupported image at %s (UID=%s, blob=%s): %s",
+                        item.get("@id"),
+                        item.get("UID"),
+                        blob_path,
+                        exc,
+                    )
             field_value = klass(
                 data=blobdata,
                 contentType=content_type,


### PR DESCRIPTION
Give additional information about the images that fail in PIL, to assist in fixing their problem, otherwise the log info is unhelpful:
`WARNING [plone.namedfile.utils:216][waitress-2] PIL can not recognize the image. Image is probably broken or of a non-supported format.`